### PR TITLE
Get rid of "constexpr auto DI = PointDesc::DI;" to work with the newest CarpetX

### DIFF
--- a/AsterSeeds/src/seeds_utils.hxx
+++ b/AsterSeeds/src/seeds_utils.hxx
@@ -20,13 +20,12 @@ inline CCTK_ATTRIBUTE_ALWAYS_INLINE CCTK_DEVICE CCTK_HOST T pow2(T x) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_c2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I - DI[0] * di - DI[1] * dj - DI[2] * dk);
+        gf_avg += gf(p.I - p.DI[0] * di - p.DI[1] * dj - p.DI[2] * dk);
       }
     }
   }

--- a/AsterX/src/computeBfromA.cxx
+++ b/AsterX/src/computeBfromA.cxx
@@ -23,7 +23,6 @@ template <int dir> void ComputeStaggeredB(CCTK_ARGUMENTS) {
                       CCTK_DELTA_SPACE(2)};
   const std::array idx{1 / dx[0], 1 / dx[1], 1 / dx[2]};
 
-  constexpr auto DI = PointDesc::DI;
 
   static_assert(dir >= 0 && dir < 3, "");
 
@@ -33,9 +32,9 @@ template <int dir> void ComputeStaggeredB(CCTK_ARGUMENTS) {
       grid.nghostzones,
       [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
         // Neighbouring "plus" and "minus" cell indices
-        const auto ipjk = p.I + DI[0];
-        const auto ijpk = p.I + DI[1];
-        const auto ijkp = p.I + DI[2];
+        const auto ipjk = p.I + p.DI[0];
+        const auto ijpk = p.I + p.DI[1];
+        const auto ijkp = p.I + p.DI[2];
 
         if (dir == 0) {
           /* dBx is curl(A) at (i-1/2,j,k) */
@@ -68,14 +67,13 @@ extern "C" void AsterX_ComputedBFromdBstag(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTSX_AsterX_ComputedBFromdBstag;
   DECLARE_CCTK_PARAMETERS;
 
-  constexpr auto DI = PointDesc::DI;
   grid.loop_int_device<1, 1, 1>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
         // Neighbouring "plus" and "minus" cell indices
-        const auto ipjk = p.I + DI[0];
-        const auto ijpk = p.I + DI[1];
-        const auto ijkp = p.I + DI[2];
+        const auto ipjk = p.I + p.DI[0];
+        const auto ijpk = p.I + p.DI[1];
+        const auto ijkp = p.I + p.DI[2];
 
         /* Second order interpolation of staggered B components to cell center
          */

--- a/AsterX/src/estimate_error.hxx
+++ b/AsterX/src/estimate_error.hxx
@@ -15,12 +15,11 @@ using namespace std;
 template <typename T>
 CCTK_DEVICE inline T calc_grad_1st(const Loop::GF3D2<const T> &gf,
                                    const Loop::PointDesc &p) {
-  constexpr auto DI = Loop::PointDesc::DI;
   CCTK_REAL err{0}, errp{0}, errm{0};
   for (int d = 0; d < Loop::dim; ++d) {
-    auto varm = gf(p.I - DI[d]);
+    auto varm = gf(p.I - p.DI[d]);
     auto var0 = gf(p.I);
-    auto varp = gf(p.I + DI[d]);
+    auto varp = gf(p.I + p.DI[d]);
     errp += (varp - var0) * (varp - var0);
     errm += (var0 - varm) * (var0 - varm);
   }
@@ -32,12 +31,11 @@ CCTK_DEVICE inline T calc_grad_1st(const Loop::GF3D2<const T> &gf,
 template <typename T>
 CCTK_DEVICE inline T calc_deriv_1st(const Loop::GF3D2<const T> &gf,
                                     const Loop::PointDesc &p) {
-  constexpr auto DI = Loop::PointDesc::DI;
   CCTK_REAL err{0};
   for (int d = 0; d < Loop::dim; ++d) {
-    auto varm = gf(p.I - DI[d]);
+    auto varm = gf(p.I - p.DI[d]);
     auto var0 = gf(p.I);
-    auto varp = gf(p.I + DI[d]);
+    auto varp = gf(p.I + p.DI[d]);
     err = max({err, fabs(var0 - varm), fabs(varp - var0)});
   }
   return err;
@@ -47,12 +45,11 @@ CCTK_DEVICE inline T calc_deriv_1st(const Loop::GF3D2<const T> &gf,
 template <typename T>
 CCTK_DEVICE inline T calc_deriv_2nd(const Loop::GF3D2<const T> &gf,
                                     const Loop::PointDesc &p) {
-  constexpr auto DI = Loop::PointDesc::DI;
   CCTK_REAL err{0};
   for (int d = 0; d < Loop::dim; ++d) {
-    auto varm = gf(p.I - DI[d]);
+    auto varm = gf(p.I - p.DI[d]);
     auto var0 = gf(p.I);
-    auto varp = gf(p.I + DI[d]);
+    auto varp = gf(p.I + p.DI[d]);
     err = max({err, fabs(varp + varm - 2 * var0)});
   }
   return err;

--- a/AsterX/src/fluxes.cxx
+++ b/AsterX/src/fluxes.cxx
@@ -318,7 +318,6 @@ void CalcFlux(CCTK_ARGUMENTS, EOSType &eos_th) {
             isnan(fluxmomzs(dir)(p.I)) || isnan(flux_tau(0)) ||
             isnan(flux_tau(1)) || isnan(tau_rc(0)) || isnan(tau_rc(1)) ||
             isnan(fluxtaus(dir)(p.I))) {
-          constexpr auto DI = PointDesc::DI;
           printf("cctk_iteration = %i,  dir = %i,  ijk = %i, %i, %i. \n",
                  cctk_iteration, dir, p.i, p.j, p.k);
           printf("  x, y, z = %16.8e, %16.8e, %16.8e.\n", p.x, p.y, p.z);
@@ -344,8 +343,8 @@ void CalcFlux(CCTK_ARGUMENTS, EOSType &eos_th) {
           printf("  g_gf   = %16.8e, %16.8e, %16.8e, %16.8e, %16.8e, %16.8e.\n",
                  gxx(p.I), gxy(p.I), gxz(p.I), gyy(p.I), gyz(p.I), gzz(p.I));
           printf("  g_gf+1 = %16.8e, %16.8e, %16.8e, %16.8e, %16.8e, %16.8e.\n",
-                 gxx(p.I + DI[dir]), gxy(p.I + DI[dir]), gxz(p.I + DI[dir]),
-                 gyy(p.I + DI[dir]), gyz(p.I + DI[dir]), gzz(p.I + DI[dir]));
+                 gxx(p.I + p.DI[dir]), gxy(p.I + p.DI[dir]), gxz(p.I + p.DI[dir]),
+                 gyy(p.I + p.DI[dir]), gyz(p.I + p.DI[dir]), gzz(p.I + p.DI[dir]));
           printf(
               "  vlows_rc  = %16.8e, %16.8e, %16.8e, %16.8e, %16.8e, %16.8e.\n",
               vlows_rc(0)(0), vlows_rc(0)(1), vlows_rc(1)(0), vlows_rc(1)(1),

--- a/AsterX/src/reconstruct.cxx
+++ b/AsterX/src/reconstruct.cxx
@@ -44,14 +44,13 @@ monocentral(const T &x, const T &y) {
 CCTK_DEVICE array<CCTK_REAL, 2>
 reconstruct(const GF3D2<const CCTK_REAL> &gf_var, const PointDesc &p,
             reconstruction_t reconstruction, int dir) {
-  constexpr auto DI = PointDesc::DI;
   // Neighbouring "plus" and "minus" cell indices
-  const auto Immm = p.I - 3 * DI[dir];
-  const auto Imm = p.I - 2 * DI[dir];
-  const auto Im = p.I - DI[dir];
+  const auto Immm = p.I - 3 * p.DI[dir];
+  const auto Imm = p.I - 2 * p.DI[dir];
+  const auto Im = p.I - p.DI[dir];
   const auto Ip = p.I;
-  const auto Ipp = p.I + DI[dir];
-  const auto Ippp = p.I + 2 * DI[dir];
+  const auto Ipp = p.I + p.DI[dir];
+  const auto Ippp = p.I + 2 * p.DI[dir];
 
   switch (reconstruction) {
 

--- a/AsterX/src/rhs.cxx
+++ b/AsterX/src/rhs.cxx
@@ -34,7 +34,6 @@ extern "C" void AsterX_RHS(CCTK_ARGUMENTS) {
                                 1 / CCTK_DELTA_SPACE(1),
                                 1 / CCTK_DELTA_SPACE(2)};
 
-  constexpr auto DI = PointDesc::DI;
   const vec<GF3D2<const CCTK_REAL>, dim> gf_fdens{fxdens, fydens, fzdens};
   const vec<GF3D2<const CCTK_REAL>, dim> gf_fmomx{fxmomx, fymomx, fzmomx};
   const vec<GF3D2<const CCTK_REAL>, dim> gf_fmomy{fxmomy, fymomy, fzmomy};
@@ -50,7 +49,7 @@ extern "C" void AsterX_RHS(CCTK_ARGUMENTS) {
       [=] CCTK_DEVICE(const vec<GF3D2<const CCTK_REAL>, dim> &gf_fluxes,
                       const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
         vec<CCTK_REAL, 3> dfluxes([&](int i) ARITH_INLINE {
-          return gf_fluxes(i)(p.I + DI[i]) - gf_fluxes(i)(p.I);
+          return gf_fluxes(i)(p.I + p.DI[i]) - gf_fluxes(i)(p.I);
         });
         return -calc_contraction(idx, dfluxes);
       };
@@ -61,8 +60,8 @@ extern "C" void AsterX_RHS(CCTK_ARGUMENTS) {
         const int k = (i == 0) ? 2 : ((i == 1) ? 0 : 1);
 
         const CCTK_REAL E =
-            0.25 * ((gf_fBs(j)(k)(p.I) + gf_fBs(j)(k)(p.I - DI[j])) -
-                    (gf_fBs(k)(j)(p.I) + gf_fBs(k)(j)(p.I - DI[k])));
+            0.25 * ((gf_fBs(j)(k)(p.I) + gf_fBs(j)(k)(p.I - p.DI[j])) -
+                    (gf_fBs(k)(j)(p.I) + gf_fBs(k)(j)(p.I - p.DI[k])));
 
         switch (gauge) {
         case vector_potential_gauge_t::algebraic: {
@@ -91,7 +90,7 @@ extern "C" void AsterX_RHS(CCTK_ARGUMENTS) {
           printf("densrhs = %f, gf_fdens = %f, %f, %f, %f, %f, %f \n",
               densrhs(p.I),
               gf_fdens(0)(p.I), gf_fdens(1)(p.I), gf_fdens(2)(p.I),
-              gf_fdens(0)(p.I + DI[0]), gf_fdens(1)(p.I + DI[1]), gf_fdens(2)(p.I + DI[2]));
+              gf_fdens(0)(p.I + p.DI[0]), gf_fdens(1)(p.I + p.DI[1]), gf_fdens(2)(p.I + p.DI[2]));
         }
         assert(!isnan(densrhs(p.I)));
       });

--- a/AsterX/src/utils.hxx
+++ b/AsterX/src/utils.hxx
@@ -148,9 +148,8 @@ template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2v_oneside(const GF3D2<const T> &gf, const PointDesc &p,
                      const int dir, const int sign) {
-  constexpr auto DI = PointDesc::DI;
   return -sign *
-         (gf(p.I + 2 * sign * DI[dir]) - 4.0 * gf(p.I + sign * DI[dir]) +
+         (gf(p.I + 2 * sign * p.DI[dir]) - 4.0 * gf(p.I + sign * p.DI[dir]) +
           3.0 * gf(p.I)) *
          (0.5 / p.DX[dir]);
 }
@@ -159,32 +158,29 @@ calc_fd2_v2v_oneside(const GF3D2<const T> &gf, const PointDesc &p,
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_c2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
-  return (0.5 / p.DX[dir]) * (gf(p.I + DI[dir]) - gf(p.I - DI[dir]));
+  return (0.5 / p.DX[dir]) * (gf(p.I + p.DI[dir]) - gf(p.I - p.DI[dir]));
 }
 
 // FD2: vertex centered input, edge centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
-  return (gf(p.I + DI[dir]) - gf(p.I)) / p.DX[dir];
+  return (gf(p.I + p.DI[dir]) - gf(p.I)) / p.DX[dir];
 }
 
 // FD2: vertex centered input, cell centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
-  constexpr auto DI = PointDesc::DI;
   T dgf1, dgf2, dgf3, dgf4;
   const int dir1 = (dir == 0) ? 1 : ((dir == 1) ? 2 : 0);
   const int dir2 = (dir == 0) ? 2 : ((dir == 1) ? 0 : 1);
 
-  dgf1 = (gf(p.I + DI[dir]) - gf(p.I)) / p.DX[dir];
-  dgf2 = (gf(p.I + DI[dir1] + DI[dir]) - gf(p.I + DI[dir1])) / p.DX[dir];
-  dgf3 = (gf(p.I + DI[dir2] + DI[dir]) - gf(p.I + DI[dir2])) / p.DX[dir];
-  dgf4 = (gf(p.I + DI[dir1] + DI[dir2] + DI[dir]) -
-          gf(p.I + DI[dir1] + DI[dir2])) /
+  dgf1 = (gf(p.I + p.DI[dir]) - gf(p.I)) / p.DX[dir];
+  dgf2 = (gf(p.I + p.DI[dir1] + p.DI[dir]) - gf(p.I + p.DI[dir1])) / p.DX[dir];
+  dgf3 = (gf(p.I + p.DI[dir2] + p.DI[dir]) - gf(p.I + p.DI[dir2])) / p.DX[dir];
+  dgf4 = (gf(p.I + p.DI[dir1] + p.DI[dir2] + p.DI[dir]) -
+          gf(p.I + p.DI[dir1] + p.DI[dir2])) /
          p.DX[dir];
 
   return 0.25 * (dgf1 + dgf2 + dgf3 + dgf4);
@@ -194,17 +190,15 @@ calc_fd2_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd4_c2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   return (1.0 / (12.0 * p.DX[dir])) *
-         (-gf(p.I + 2 * DI[dir]) + 8.0 * gf(p.I + DI[dir]) -
-          8.0 * gf(p.I - DI[dir]) + gf(p.I - 2 * DI[dir]));
+         (-gf(p.I + 2 * p.DI[dir]) + 8.0 * gf(p.I + p.DI[dir]) -
+          8.0 * gf(p.I - p.DI[dir]) + gf(p.I - 2 * p.DI[dir]));
 }
 
 // FD4: vertex centered input, cell centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
-  constexpr auto DI = PointDesc::DI;
   T dgf1, dgf2, dgf3, dgf4;
   T dgf5, dgf6, dgf7, dgf8;
   int dir1, dir2;
@@ -221,47 +215,47 @@ calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
   }
 
   dgf1 =
-      ((1.0 / 24.0) * gf(p.I + 2 * DI[dir]) - (9.0 / 8.0) * gf(p.I + DI[dir]) +
-       (9.0 / 8.0) * gf(p.I) - (1.0 / 24.0) * gf(p.I - DI[dir])) /
+      ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir]) - (9.0 / 8.0) * gf(p.I + p.DI[dir]) +
+       (9.0 / 8.0) * gf(p.I) - (1.0 / 24.0) * gf(p.I - p.DI[dir])) /
       p.DX[dir];
-  dgf2 = ((1.0 / 24.0) * gf(p.I + DI[dir1] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir1]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir1] - DI[dir])) /
+  dgf2 = ((1.0 / 24.0) * gf(p.I + p.DI[dir1] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir1] - p.DI[dir])) /
          p.DX[dir];
-  dgf3 = ((1.0 / 24.0) * gf(p.I + DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir2] - DI[dir])) /
+  dgf3 = ((1.0 / 24.0) * gf(p.I + p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
-  dgf4 = ((1.0 / 24.0) * gf(p.I + DI[dir1] + DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir1] + DI[dir2] - DI[dir])) /
-         p.DX[dir];
-
-  dgf5 = ((1.0 / 24.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] - DI[dir])) /
+  dgf4 = ((1.0 / 24.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf6 = ((1.0 / 24.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] - DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] - DI[dir])) /
+  dgf5 = ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf7 = ((1.0 / 24.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I - DI[dir1] + 2 * DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] - DI[dir])) /
+  dgf6 = ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf8 = ((1.0 / 24.0) * gf(p.I - DI[dir1] - DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I - DI[dir1] - DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I - DI[dir1] - DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I - DI[dir1] - DI[dir2] - DI[dir])) /
+  dgf7 = ((1.0 / 24.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] - p.DI[dir])) /
+         p.DX[dir];
+
+  dgf8 = ((1.0 / 24.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] - p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
   return (27.0 / 14.0) * (dgf1 + dgf2 + dgf3 + dgf4) -
@@ -272,13 +266,12 @@ calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_v2c(const GF3D2<const T> &gf, const PointDesc &p) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < 2; ++dk) {
     for (int dj = 0; dj < 2; ++dj) {
       for (int di = 0; di < 2; ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -289,11 +282,10 @@ calc_avg_v2c(const GF3D2<const T> &gf, const PointDesc &p) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_e2v(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int di = 0; di < 2; ++di) {
-    gf_avg += gf(p.I - DI[dir] * di);
+    gf_avg += gf(p.I - p.DI[dir] * di);
   }
   return gf_avg / 2.0;
 }
@@ -303,13 +295,12 @@ calc_avg_e2v(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -321,13 +312,12 @@ calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_v2f(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -338,13 +328,12 @@ calc_avg_v2f(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_c2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I - DI[0] * di - DI[1] * dj - DI[2] * dk);
+        gf_avg += gf(p.I - p.DI[0] * di - p.DI[1] * dj - p.DI[2] * dk);
       }
     }
   }
@@ -354,9 +343,8 @@ calc_avg_c2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline vec<T, 6>
 get_neighbors(const GF3D2<T> &gf, const PointDesc &p) {
-  constexpr auto DI = PointDesc::DI;
-  return {gf(p.I - DI[0]), gf(p.I + DI[0]), gf(p.I - DI[1]),
-          gf(p.I + DI[1]), gf(p.I - DI[2]), gf(p.I + DI[2])};
+  return {gf(p.I - p.DI[0]), gf(p.I + p.DI[0]), gf(p.I - p.DI[1]),
+          gf(p.I + p.DI[1]), gf(p.I - p.DI[2]), gf(p.I + p.DI[2])};
 }
 
 template <typename T, int D>

--- a/Con2PrimFactory/src/c2p_utils.hxx
+++ b/Con2PrimFactory/src/c2p_utils.hxx
@@ -144,9 +144,8 @@ template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2v_oneside(const GF3D2<const T> &gf, const PointDesc &p,
                      const int dir, const int sign) {
-  constexpr auto DI = PointDesc::DI;
   return -sign *
-         (gf(p.I + 2 * sign * DI[dir]) - 4.0 * gf(p.I + sign * DI[dir]) +
+         (gf(p.I + 2 * sign * p.DI[dir]) - 4.0 * gf(p.I + sign * p.DI[dir]) +
           3.0 * gf(p.I)) *
          (0.5 / p.DX[dir]);
 }
@@ -155,23 +154,20 @@ calc_fd2_v2v_oneside(const GF3D2<const T> &gf, const PointDesc &p,
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_c2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
-  return (0.5 / p.DX[dir]) * (gf(p.I + DI[dir]) - gf(p.I - DI[dir]));
+  return (0.5 / p.DX[dir]) * (gf(p.I + p.DI[dir]) - gf(p.I - p.DI[dir]));
 }
 
 // FD2: vertex centered input, edge centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
-  return (gf(p.I + DI[dir]) - gf(p.I)) / p.DX[dir];
+  return (gf(p.I + p.DI[dir]) - gf(p.I)) / p.DX[dir];
 }
 
 // FD2: vertex centered input, cell centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd2_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
-  constexpr auto DI = PointDesc::DI;
   T dgf1, dgf2, dgf3, dgf4;
   int dir1, dir2;
   if (dir == 0) {
@@ -185,11 +181,11 @@ calc_fd2_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
     dir2 = 1;
   }
 
-  dgf1 = (gf(p.I + DI[dir]) - gf(p.I)) / p.DX[dir];
-  dgf2 = (gf(p.I + DI[dir1] + DI[dir]) - gf(p.I + DI[dir1])) / p.DX[dir];
-  dgf3 = (gf(p.I + DI[dir2] + DI[dir]) - gf(p.I + DI[dir2])) / p.DX[dir];
-  dgf4 = (gf(p.I + DI[dir1] + DI[dir2] + DI[dir]) -
-          gf(p.I + DI[dir1] + DI[dir2])) /
+  dgf1 = (gf(p.I + p.DI[dir]) - gf(p.I)) / p.DX[dir];
+  dgf2 = (gf(p.I + p.DI[dir1] + p.DI[dir]) - gf(p.I + p.DI[dir1])) / p.DX[dir];
+  dgf3 = (gf(p.I + p.DI[dir2] + p.DI[dir]) - gf(p.I + p.DI[dir2])) / p.DX[dir];
+  dgf4 = (gf(p.I + p.DI[dir1] + p.DI[dir2] + p.DI[dir]) -
+          gf(p.I + p.DI[dir1] + p.DI[dir2])) /
          p.DX[dir];
 
   return 0.25 * (dgf1 + dgf2 + dgf3 + dgf4);
@@ -199,17 +195,15 @@ calc_fd2_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd4_c2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   return (1.0 / (12.0 * p.DX[dir])) *
-         (-gf(p.I + 2 * DI[dir]) + 8.0 * gf(p.I + DI[dir]) -
-          8.0 * gf(p.I - DI[dir]) + gf(p.I - 2 * DI[dir]));
+         (-gf(p.I + 2 * p.DI[dir]) + 8.0 * gf(p.I + p.DI[dir]) -
+          8.0 * gf(p.I - p.DI[dir]) + gf(p.I - 2 * p.DI[dir]));
 }
 
 // FD4: vertex centered input, cell centered output
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
-  constexpr auto DI = PointDesc::DI;
   T dgf1, dgf2, dgf3, dgf4;
   T dgf5, dgf6, dgf7, dgf8;
   int dir1, dir2;
@@ -226,47 +220,47 @@ calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
   }
 
   dgf1 =
-      ((1.0 / 24.0) * gf(p.I + 2 * DI[dir]) - (9.0 / 8.0) * gf(p.I + DI[dir]) +
-       (9.0 / 8.0) * gf(p.I) - (1.0 / 24.0) * gf(p.I - DI[dir])) /
+      ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir]) - (9.0 / 8.0) * gf(p.I + p.DI[dir]) +
+       (9.0 / 8.0) * gf(p.I) - (1.0 / 24.0) * gf(p.I - p.DI[dir])) /
       p.DX[dir];
-  dgf2 = ((1.0 / 24.0) * gf(p.I + DI[dir1] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir1]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir1] - DI[dir])) /
+  dgf2 = ((1.0 / 24.0) * gf(p.I + p.DI[dir1] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir1] - p.DI[dir])) /
          p.DX[dir];
-  dgf3 = ((1.0 / 24.0) * gf(p.I + DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir2] - DI[dir])) /
+  dgf3 = ((1.0 / 24.0) * gf(p.I + p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
-  dgf4 = ((1.0 / 24.0) * gf(p.I + DI[dir1] + DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + DI[dir1] + DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + DI[dir1] + DI[dir2] - DI[dir])) /
-         p.DX[dir];
-
-  dgf5 = ((1.0 / 24.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + 2 * DI[dir1] + 2 * DI[dir2] - DI[dir])) /
+  dgf4 = ((1.0 / 24.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + p.DI[dir1] + p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + p.DI[dir1] + p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf6 = ((1.0 / 24.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I + 2 * DI[dir1] - DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I + 2 * DI[dir1] - DI[dir2] - DI[dir])) /
+  dgf5 = ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] + 2 * p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf7 = ((1.0 / 24.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I - DI[dir1] + 2 * DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I - DI[dir1] + 2 * DI[dir2] - DI[dir])) /
+  dgf6 = ((1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I + 2 * p.DI[dir1] - p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
-  dgf8 = ((1.0 / 24.0) * gf(p.I - DI[dir1] - DI[dir2] + 2 * DI[dir]) -
-          (9.0 / 8.0) * gf(p.I - DI[dir1] - DI[dir2] + DI[dir]) +
-          (9.0 / 8.0) * gf(p.I - DI[dir1] - DI[dir2]) -
-          (1.0 / 24.0) * gf(p.I - DI[dir1] - DI[dir2] - DI[dir])) /
+  dgf7 = ((1.0 / 24.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I - p.DI[dir1] + 2 * p.DI[dir2] - p.DI[dir])) /
+         p.DX[dir];
+
+  dgf8 = ((1.0 / 24.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] + 2 * p.DI[dir]) -
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] + p.DI[dir]) +
+          (9.0 / 8.0) * gf(p.I - p.DI[dir1] - p.DI[dir2]) -
+          (1.0 / 24.0) * gf(p.I - p.DI[dir1] - p.DI[dir2] - p.DI[dir])) /
          p.DX[dir];
 
   return (27.0 / 14.0) * (dgf1 + dgf2 + dgf3 + dgf4) -
@@ -277,13 +271,12 @@ calc_fd4_v2c(const GF3D2<const T> &gf, const PointDesc &p, int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_v2c(const GF3D2<const T> &gf, const PointDesc &p) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < 2; ++dk) {
     for (int dj = 0; dj < 2; ++dj) {
       for (int di = 0; di < 2; ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -294,11 +287,10 @@ calc_avg_v2c(const GF3D2<const T> &gf, const PointDesc &p) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_e2v(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int di = 0; di < 2; ++di) {
-    gf_avg += gf(p.I - DI[dir] * di);
+    gf_avg += gf(p.I - p.DI[dir] * di);
   }
   return gf_avg / 2.0;
 }
@@ -308,13 +300,12 @@ calc_avg_e2v(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -326,13 +317,12 @@ calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_v2f(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I + DI[0] * di + DI[1] * dj + DI[2] * dk);
+        gf_avg += gf(p.I + p.DI[0] * di + p.DI[1] * dj + p.DI[2] * dk);
       }
     }
   }
@@ -343,13 +333,12 @@ calc_avg_v2f(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
 calc_avg_c2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
-  constexpr auto DI = PointDesc::DI;
   T gf_avg = 0.0;
 
   for (int dk = 0; dk < (dir == 2 ? 1 : 2); ++dk) {
     for (int dj = 0; dj < (dir == 1 ? 1 : 2); ++dj) {
       for (int di = 0; di < (dir == 0 ? 1 : 2); ++di) {
-        gf_avg += gf(p.I - DI[0] * di - DI[1] * dj - DI[2] * dk);
+        gf_avg += gf(p.I - p.DI[0] * di - p.DI[1] * dj - p.DI[2] * dk);
       }
     }
   }
@@ -359,9 +348,8 @@ calc_avg_c2e(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
 template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline vec<T, 6>
 get_neighbors(const GF3D2<T> &gf, const PointDesc &p) {
-  constexpr auto DI = PointDesc::DI;
-  return {gf(p.I - DI[0]), gf(p.I + DI[0]), gf(p.I - DI[1]),
-          gf(p.I + DI[1]), gf(p.I - DI[2]), gf(p.I + DI[2])};
+  return {gf(p.I - p.DI[0]), gf(p.I + p.DI[0]), gf(p.I - p.DI[1]),
+          gf(p.I + p.DI[1]), gf(p.I - p.DI[2]), gf(p.I + p.DI[2])};
 }
 
 template <typename T, int D>


### PR DESCRIPTION
Get rid of "constexpr auto DI = PointDesc::DI;" to work with the newest CarpetX