### PR TITLE
AsterX: Bugfix in PPM shock detection and zone flattening

### DIFF
--- a/AsterX/param.ccl
+++ b/AsterX/param.ccl
@@ -51,6 +51,16 @@ CCTK_REAL ppm_eps "epsilon parameter in the PPM zone flattening algorithm (see C
   *:* :: "Any real number, default from Colella & Woodward 1984"
 } 0.33
 
+CCTK_REAL ppm_eps_shock "Epsilon for PPM shock detection"
+{
+  *:* :: "Anything goes. Default is from Colella & Woodward"
+} 0.01
+
+CCTK_REAL ppm_small "A floor used by PPM shock detection"
+{
+  0.0:1.0       :: "In [0,1]"
+} 1.e-7
+
 CCTK_REAL ppm_omega1 "omega1 parameter in the PPM zone flattening algorithm (see Colella & Woodward 1984 eq. 1.16)"
 {
   *:* :: "Any real number, default from Colella & Woodward 1984"

--- a/AsterX/src/fluxes.cxx
+++ b/AsterX/src/fluxes.cxx
@@ -101,6 +101,8 @@ void CalcFlux(CCTK_ARGUMENTS, EOSType &eos_th) {
   reconstruct_params.ppm_eta1 = ppm_eta1;
   reconstruct_params.ppm_eta2 = ppm_eta2;
   reconstruct_params.ppm_eps = ppm_eps;
+  reconstruct_params.ppm_eps_shock = ppm_eps_shock;
+  reconstruct_params.ppm_small = ppm_small;
   reconstruct_params.ppm_omega1 = ppm_omega1;
   reconstruct_params.ppm_omega2 = ppm_omega2;
   // wenoz parameters


### PR DESCRIPTION
Bug fixes based on the Spritz code. 
Zone-flattening now works with TOV. 
New parameters introduced for shock detection mechanism. 

Testsuite runs, which use PPM, fail since PPM has been modified. Will be updated once the PR is accepted.