### PR TITLE
TOVSolver: Removed AsterX dependency

### DIFF
--- a/TOVSolver/interface.ccl
+++ b/TOVSolver/interface.ccl
@@ -2,7 +2,7 @@
 
 IMPLEMENTS: TOVSolver
 
-INHERITS: CarpetX ADMBaseX HydroBaseX AsterX
+INHERITS: CarpetX ADMBaseX HydroBaseX
 
 USES INCLUDE HEADER: fixmath.hxx
 USES INCLUDE HEADER: loop_device.hxx

--- a/TOVSolver/schedule.ccl
+++ b/TOVSolver/schedule.ccl
@@ -71,7 +71,7 @@ schedule TOV_C_Exact IN HydroBaseX_InitialData
   WRITES: HydroBaseX::vel(everywhere)
   WRITES: HydroBaseX::eps(everywhere)
   WRITES: HydroBaseX::press(everywhere)
-  WRITES: AsterX::Avec_x(everywhere) AsterX::Avec_y(everywhere) AsterX::Avec_z(everywhere)
+  WRITES: HydroBaseX::Avecx(everywhere), HydroBaseX::Avecy(everywhere) HydroBaseX::Avecz(everywhere)
 
   WRITES: metric_cell(everywhere)
   WRITES: lapse_cell(everywhere)

--- a/TOVSolver/src/tov.cxx
+++ b/TOVSolver/src/tov.cxx
@@ -107,17 +107,17 @@ extern "C" void TOV_C_Exact(CCTK_ARGUMENTS) {
     grid.loop_all<1, 0, 0>(
         grid.nghostzones,
         [=] CCTK_HOST(const Loop::PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecx(p.I) = 0.0; });
 
     grid.loop_all<0, 1, 0>(
         grid.nghostzones,
         [=] CCTK_HOST(const Loop::PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecy(p.I) = 0.0; });
 
     grid.loop_all<0, 0, 1>(
         grid.nghostzones,
         [=] CCTK_HOST(const Loop::PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avecz(p.I) = 0.0; });
   }
 
   CCTK_INT tov_lapse = CCTK_EQUALS(initial_lapse, "tov");


### PR DESCRIPTION
Now that HydroBaseX has the vector potential, TOVSolver doesn't need to depend on AsterX.