### PR TITLE
Handling BH interiors

### DIFF
--- a/AsterX/param.ccl
+++ b/AsterX/param.ccl
@@ -116,6 +116,10 @@ USES CCTK_REAL r_atmo
 USES CCTK_REAL n_rho_atmo
 USES CCTK_REAL n_press_atmo
 USES BOOLEAN thermal_eos_atmo
+USES CCTK_REAL alp_thresh
+USES CCTK_REAL rho_BH
+USES CCTK_REAL eps_BH
+USES CCTK_REAL vwlim_BH
 
 SHARES: ReconX
 USES KEYWORD reconstruction_method

--- a/AsterX/schedule.ccl
+++ b/AsterX/schedule.ccl
@@ -123,6 +123,7 @@ SCHEDULE AsterX_Con2Prim IN AsterX_Con2PrimGroup AFTER AsterX_ComputedBFromdBsta
 {
   LANG: C
   READS: ADMBaseX::metric(interior)
+  READS: ADMBaseX::lapse(everywhere)
   READS: dens(interior) tau(interior) mom(interior) dB(interior)
   READS: saved_prims(interior)
   READS: Avec_x(interior) Avec_y(interior) Avec_z(interior)

--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -142,16 +142,16 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
         pv_seeds.Ye = Ye_atmo;
         pv_seeds.press =
             eos_th.press_from_valid_rho_eps_ye(rho_BH, eps_BH, Ye_atmo);
-        if ( ((pv_seeds.vel(0) * pv_seeds.w_lor) > vwlim_BH) || 
-             ((pv_seeds.vel(1)*pv_seeds.w_lor) > vwlim_BH) || 
-             ((pv_seeds.vel(2)*pv_seeds.w_lor) > vwlim_BH) ) {
-            CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
-            CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
-            pv_seeds.vel(0) *= vlim_BH / pv_seeds.vel(0);
-            pv_seeds.vel(1) *= vlim_BH / pv_seeds.vel(1);
-            pv_seeds.vel(2) *= vlim_BH / pv_seeds.vel(2);
-            pv_seeds.w_lor = wlim_BH;
-          }
+        // check on velocities
+        CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
+        CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
+        vec<CCTK_REAL, 3> v_low = calc_contraction(glo, pv_seeds.vel);
+        CCTK_REAL vsq = calc_contraction(v_low, pv_seeds.vel);
+        CCTK_REAL sol_v = sqrt(vsq);
+        if (sol_v > vlim_BH) {
+          pv_seeds.vel *= vlim_BH/sol_v; 
+          pv_seeds.w_lor = wlim_BH;
+        }
         cv.from_prim(pv_seeds, glo);
       }
     }
@@ -210,16 +210,16 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
           pv.Ye = Ye_atmo;
           pv.press =
               eos_th.press_from_valid_rho_eps_ye(rho_BH, eps_BH, Ye_atmo);
-          if (((pv.vel(0) * pv.w_lor) > vwlim_BH) || 
-              ((pv.vel(1)*pv.w_lor) > vwlim_BH) || 
-              ((pv.vel(2)*pv.w_lor) > vwlim_BH) ) {
-              CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
-              CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
-              pv.vel(0) *= vlim_BH / pv.vel(0);
-              pv.vel(1) *= vlim_BH / pv.vel(1);
-              pv.vel(2) *= vlim_BH / pv.vel(2);
-              pv.w_lor = wlim_BH;
-            }
+          // check on velocities
+          CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
+          CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
+          vec<CCTK_REAL, 3> v_low = calc_contraction(glo, pv.vel);
+          CCTK_REAL vsq = calc_contraction(v_low, pv.vel);
+          CCTK_REAL sol_v = sqrt(vsq);
+          if (sol_v > vlim_BH) {
+            pv.vel *= vlim_BH/sol_v;
+            pv.w_lor = wlim_BH;
+          }
           cv.from_prim(pv, glo);
           rep_first.set_atmo = 0;
           rep_second.set_atmo = 0;

--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -145,11 +145,10 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
         // check on velocities
         CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
         CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
-        vec<CCTK_REAL, 3> v_low = calc_contraction(glo, pv_seeds.vel);
-        CCTK_REAL vsq = calc_contraction(v_low, pv_seeds.vel);
-        CCTK_REAL sol_v = sqrt(vsq);
+        CCTK_REAL sol_v =
+            sqrt((pv_seeds.w_lor * pv_seeds.w_lor - 1.0)) / pv_seeds.w_lor;
         if (sol_v > vlim_BH) {
-          pv_seeds.vel *= vlim_BH/sol_v; 
+          pv_seeds.vel *= vlim_BH / sol_v;
           pv_seeds.w_lor = wlim_BH;
         }
         cv.from_prim(pv_seeds, glo);
@@ -213,11 +212,9 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
           // check on velocities
           CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
           CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
-          vec<CCTK_REAL, 3> v_low = calc_contraction(glo, pv.vel);
-          CCTK_REAL vsq = calc_contraction(v_low, pv.vel);
-          CCTK_REAL sol_v = sqrt(vsq);
+          CCTK_REAL sol_v = sqrt((pv.w_lor * pv.w_lor - 1.0)) / pv.w_lor;
           if (sol_v > vlim_BH) {
-            pv.vel *= vlim_BH/sol_v;
+            pv.vel *= vlim_BH / sol_v;
             pv.w_lor = wlim_BH;
           }
           cv.from_prim(pv, glo);

--- a/AsterX/src/con2prim_rpa.cxx
+++ b/AsterX/src/con2prim_rpa.cxx
@@ -84,6 +84,10 @@ extern "C" void AsterX_Con2Prim(CCTK_ARGUMENTS) {
     sm_metric3 g(sm_symt3l(glo(0, 0), glo(0, 1), glo(1, 1), glo(0, 2),
                            glo(1, 2), glo(2, 2)));
 
+    /* Get covariant metric used for BH interior fixes */
+    const smat<CCTK_REAL, 3> glow(
+        [&](int i, int j) ARITH_INLINE { return calc_avg_v2c(gf_g(i, j), p); });
+
     /* Calculate inverse of 3-metric */
     const CCTK_REAL spatial_detg = calc_det(glo);
     const CCTK_REAL sqrt_detg = sqrt(spatial_detg);
@@ -105,6 +109,66 @@ extern "C" void AsterX_Con2Prim(CCTK_ARGUMENTS) {
                      {momx(p.I), momy(p.I), momz(p.I)},
                      {dBx(p.I), dBy(p.I), dBz(p.I)}};
 
+
+    // Modifying primitive seeds within BH interiors before C2Ps are called
+    // NOTE: By default, alp_thresh=0 so the if condition below is never
+    // triggered. One must be very careful when using this functionality and
+    // must correctly set alp_thresh, rho_BH, eps_BH and vwlim_BH in the parfile
+
+    if (alp(p.I) < alp_thresh) {
+      if ((pv_seeds.rho > rho_BH) || (pv_seeds.eps > eps_BH)) {
+        pv_seeds.rho = rho_BH; // typically set to 0.01% to 1% of rho_max of
+                               // initial NS or disk
+        pv_seeds.eps = eps_BH;
+        pv_seeds.ye = Ye_atmo;
+        pv_seeds.press =
+            eos.at_rho_eps_ye(rho_BH, eps_BH, Ye_atmo).press();
+        if ( ((pv_seeds.vel(0) * pv_seeds.w_lor) > vwlim_BH) ||
+             ((pv_seeds.vel(1)*pv_seeds.w_lor) > vwlim_BH) ||
+             ((pv_seeds.vel(2)*pv_seeds.w_lor) > vwlim_BH) ) {
+            CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
+            CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
+            pv_seeds.vel(0) *= vlim_BH / pv_seeds.vel(0);
+            pv_seeds.vel(1) *= vlim_BH / pv_seeds.vel(1);
+            pv_seeds.vel(2) *= vlim_BH / pv_seeds.vel(2);
+            pv_seeds.w_lor = wlim_BH;
+          }
+        // cv.from_prim(pv_seeds, g);
+        // We do not save electric field, required by cv.from_prim(pv_seeds, g) in RPA.
+        // Thus, we recompute the CVs explicitly below
+
+        const vec<CCTK_REAL, 3> &v_up = pv_seeds.vel;
+        const vec<CCTK_REAL, 3> v_low = calc_contraction(glow, v_up);
+        /* Computing B_j */
+        const vec<CCTK_REAL, 3> &B_up = pv_seeds.B;
+        const vec<CCTK_REAL, 3> B_low = calc_contraction(glow, B_up);
+        /* Computing b^t : this is b^0 * alp */
+        const CCTK_REAL bst = pv_seeds.w_lor * calc_contraction(B_up, v_low);
+        /* Computing b_j */
+        const vec<CCTK_REAL, 3> b_low = B_low / pv_seeds.w_lor + bst * v_low;
+        /* Computing b^mu b_mu */
+        const CCTK_REAL bs2 =
+            (calc_contraction(B_up, B_low) + bst * bst) / (pv_seeds.w_lor * pv_seeds.w_lor); 
+        // computing conserved from primitives
+        cv.dens = sqrt_detg * pv_seeds.rho * pv_seeds.w_lor;
+        cv.scon(0) = sqrt_detg * (pv_seeds.w_lor * pv_seeds.w_lor *
+                           (pv_seeds.rho * (1.0 + pv_seeds.eps) + pv_seeds.press + bs2) * v_low(0) -
+                       bst * b_low(0));
+        cv.scon(1) = sqrt_detg * (pv_seeds.w_lor * pv_seeds.w_lor *
+                           (pv_seeds.rho * (1.0 + pv_seeds.eps) + pv_seeds.press + bs2) * v_low(1) -
+                       bst * b_low(1));
+        cv.scon(2) = sqrt_detg * (pv_seeds.w_lor * pv_seeds.w_lor *
+                           (pv_seeds.rho * (1.0 + pv_seeds.eps) + pv_seeds.press + bs2) * v_low(2) -
+                       bst * b_low(2));
+        cv.tau = sqrt_detg * (pv_seeds.w_lor * pv_seeds.w_lor *
+                           (pv_seeds.rho * (1.0 + pv_seeds.eps) + pv_seeds.press + bs2) -
+                       (pv_seeds.press + 0.5 * bs2) - bst * bst) - cv.dens;
+        cv.bcons = sqrt_detg * pv_seeds.B;
+        cv.tracer_ye = cv.dens * pv_seeds.ye;       
+      }
+    }
+
+    // Calling C2P
     cv2pv(pv, cv, g, rep);
 
     // Handle incorrectable errors
@@ -115,8 +179,7 @@ extern "C" void AsterX_Con2Prim(CCTK_ARGUMENTS) {
         // need to fix pv to computed values like pv.rho instead of rho(p.I)
         printf(
             "WARNING: "
-            "C2P failed. Printing cons and saved prims before set to "
-            "atmo: \n"
+            "C2P failed. Printing cons and saved prims before set to atmo or BH interior fix: \n"
             "cctk_iteration = %i \n "
             "x, y, z = %26.16e, %26.16e, %26.16e \n "
             "gxx, gxy, gxz, gyy, gyz, gzz = %f, %f, %f, %f, %f, %f \n "
@@ -138,12 +201,67 @@ extern "C" void AsterX_Con2Prim(CCTK_ARGUMENTS) {
             // velz(p.I), Bvecx(p.I), Bvecy(p.I), Bvecz(p.I),
             Avec_x(p.I), Avec_y(p.I), Avec_z(p.I));
       }
-      // set to atmo
-      cv.bcons(0) = dBx(p.I);
-      cv.bcons(1) = dBy(p.I);
-      cv.bcons(2) = dBz(p.I);
-      pv.B = cv.bcons / sqrt_detg;
-      atmo.set(pv, cv, g);
+
+      if (alp(p.I) < alp_thresh) {
+        if ((pv.rho > rho_BH) || (pv.eps > eps_BH)) {
+          pv.rho = rho_BH; // typically set to 0.01% to 1% of rho_max of
+                               // initial NS or disk
+          pv.eps = eps_BH;
+          pv.ye = Ye_atmo;
+          pv.press =
+              eos.at_rho_eps_ye(rho_BH, eps_BH, Ye_atmo).press();
+          if (((pv.vel(0) * pv.w_lor) > vwlim_BH) ||
+               ((pv.vel(1)*pv.w_lor) > vwlim_BH) ||
+               ((pv.vel(2)*pv.w_lor) > vwlim_BH) ) {
+              CCTK_REAL wlim_BH = sqrt(1.0 + vwlim_BH * vwlim_BH);
+              CCTK_REAL vlim_BH = vwlim_BH / wlim_BH;
+              pv.vel(0) *= vlim_BH / pv.vel(0);
+              pv.vel(1) *= vlim_BH / pv.vel(1);
+              pv.vel(2) *= vlim_BH / pv.vel(2);
+              pv.w_lor = wlim_BH;
+          }
+          // cv.from_prim(pv, g);
+          // We do not save electric field, required by cv.from_prim(pv, g) in RPA.
+          // Thus, we recompute the CVs explicitly below
+
+          const vec<CCTK_REAL, 3> &v_up = pv.vel;
+          const vec<CCTK_REAL, 3> v_low = calc_contraction(glow, v_up);
+          /* Computing B_j */
+          const vec<CCTK_REAL, 3> &B_up = pv.B;
+          const vec<CCTK_REAL, 3> B_low = calc_contraction(glow, B_up);
+          /* Computing b^t : this is b^0 * alp */
+          const CCTK_REAL bst = pv.w_lor * calc_contraction(B_up, v_low);
+          /* Computing b_j */
+          const vec<CCTK_REAL, 3> b_low = B_low / pv.w_lor + bst * v_low;
+          /* Computing b^mu b_mu */
+          const CCTK_REAL bs2 =
+              (calc_contraction(B_up, B_low) + bst * bst) / (pv.w_lor * pv.w_lor);
+          // computing conserved from primitives
+          cv.dens = sqrt_detg * pv.rho * pv.w_lor;
+          cv.scon(0) = sqrt_detg * (pv.w_lor * pv.w_lor *
+                           (pv.rho * (1.0 + pv.eps) + pv.press + bs2) * v_low(0) -
+                       bst * b_low(0));
+          cv.scon(1) = sqrt_detg * (pv.w_lor * pv.w_lor *
+                           (pv.rho * (1.0 + pv.eps) + pv.press + bs2) * v_low(1) -
+                       bst * b_low(1));
+          cv.scon(2) = sqrt_detg * (pv.w_lor * pv.w_lor *
+                           (pv.rho * (1.0 + pv.eps) + pv.press + bs2) * v_low(2) -
+                       bst * b_low(2));
+          cv.tau = sqrt_detg * (pv.w_lor * pv.w_lor *
+                            (pv.rho * (1.0 + pv.eps) + pv.press + bs2) -
+                       (pv.press + 0.5 * bs2) - bst * bst) - cv.dens;
+          cv.bcons = sqrt_detg * pv.B;
+          cv.tracer_ye = cv.dens * pv.ye;
+        }
+      }
+      else {
+        // set to atmo
+        cv.bcons(0) = dBx(p.I);
+        cv.bcons(1) = dBy(p.I);
+        cv.bcons(2) = dBz(p.I);
+        pv.B = cv.bcons / sqrt_detg;
+        atmo.set(pv, cv, g);
+      }
     }
 
     /* set flag to success */

--- a/Con2PrimFactory/param.ccl
+++ b/Con2PrimFactory/param.ccl
@@ -111,5 +111,5 @@ CCTK_REAL eps_BH " Maximum eps allowed in regions where alp<alp_thresh" STEERABL
 
 CCTK_REAL vwlim_BH " Maximum zvec (v*w) allowed in regions where alp<alp_thresh" STEERABLE=ALWAYS
 {
-  1.0:* :: ""
+  0.0:* :: ""
 } 1.0e100

--- a/Con2PrimFactory/param.ccl
+++ b/Con2PrimFactory/param.ccl
@@ -92,3 +92,24 @@ BOOLEAN thermal_eos_atmo "Whether to use the thermal (evolution) EOS for setting
 {
 }  "no"
 
+# Parameters for BH treatment
+
+CCTK_REAL alp_thresh "Lapse threshold below which primitives are modified for stability, specifically inside BH interior. Value should be set such that it is lesser than the lapse at the apparent horizon " STEERABLE=ALWAYS
+{
+  0.0:* :: ""
+} 0.0
+
+CCTK_REAL rho_BH " Maximum density allowed in regions where alp<alp_thresh" STEERABLE=ALWAYS
+{
+  0.0:* :: ""
+} 1.0e100
+
+CCTK_REAL eps_BH " Maximum eps allowed in regions where alp<alp_thresh" STEERABLE=ALWAYS
+{
+  0.0:* :: ""
+} 1.0e100
+
+CCTK_REAL vwlim_BH " Maximum zvec (v*w) allowed in regions where alp<alp_thresh" STEERABLE=ALWAYS
+{
+  1.0:* :: ""
+} 1.0e100


### PR DESCRIPTION
Added code in C2P wrapper to handle the hydrodynamics within BH interior, set via the threshold parameter for lapse `alp_thresh`.

By default, the functionality is inactive, as `alp_thresh=0` in `param.ccl`.

One must be very careful when using this functionality, and must correctly set the parameters `alp_thresh`, `rho_BH`, `eps_BH` and `vwlim_BH` in the parfile.