### PR TITLE
Extend Balsara's tests to arbitrary directions.

### DIFF
--- a/AsterSeeds/param.ccl
+++ b/AsterSeeds/param.ccl
@@ -43,7 +43,17 @@ KEYWORD rotate_axis "Rotation about which axis" STEERABLE=never
   "z" :: ""
 } "z"
 
-REAL rotate_angle "Rotation angle (in units of pi)" STEERABLE=never
+REAL rotate_angle_x "Rotation angle about x-axis (in units of pi)" STEERABLE=never
+{
+  *:* :: ""
+} 0.0
+
+REAL rotate_angle_y "Rotation angle about y-axis (in units of pi)" STEERABLE=never
+{
+  *:* :: ""
+} 0.0
+
+REAL rotate_angle_z "Rotation angle about z-axis (in units of pi)" STEERABLE=never
 {
   *:* :: ""
 } 0.5

--- a/AsterSeeds/param.ccl
+++ b/AsterSeeds/param.ccl
@@ -32,17 +32,6 @@ KEYWORD test_case "Name of the testcase" STEERABLE=never
 private:
 
 # parameters for rotating intial data
-BOOLEAN rotate_initial_data "Rotate initial data" STEERABLE=never
-{
-} no
-
-KEYWORD rotate_axis "Rotation about which axis" STEERABLE=never
-{
-  "x" :: ""
-  "y" :: ""
-  "z" :: ""
-} "z"
-
 REAL rotate_angle_x "Rotation angle about x-axis (in units of pi)" STEERABLE=never
 {
   *:* :: ""

--- a/AsterSeeds/param.ccl
+++ b/AsterSeeds/param.ccl
@@ -56,11 +56,6 @@ REAL rotate_angle_y "Rotation angle about y-axis (in units of pi)" STEERABLE=nev
 REAL rotate_angle_z "Rotation angle about z-axis (in units of pi)" STEERABLE=never
 {
   *:* :: ""
-} 0.5
-
-REAL rotate_shift "Rotation shift (b in y=kx+b, where k=tan(angle))" STEERABLE=never
-{
-  *:* :: ""
 } 0.0
 
 # parameters for atmosphere

--- a/AsterSeeds/param.ccl
+++ b/AsterSeeds/param.ccl
@@ -31,6 +31,28 @@ KEYWORD test_case "Name of the testcase" STEERABLE=never
 
 private:
 
+# parameters for rotating intial data
+BOOLEAN rotate_initial_data "Rotate initial data" STEERABLE=never
+{
+} no
+
+KEYWORD rotate_axis "Rotation about which axis" STEERABLE=never
+{
+  "x" :: ""
+  "y" :: ""
+  "z" :: ""
+} "z"
+
+REAL rotate_angle "Rotation angle (in units of pi)" STEERABLE=never
+{
+  *:* :: ""
+} 0.5
+
+REAL rotate_shift "Rotation shift (b in y=kx+b, where k=tan(angle))" STEERABLE=never
+{
+  *:* :: ""
+} 0.0
+
 # parameters for atmosphere
 
 REAL rho_atmosphere "floor density in the atmosphere"

--- a/AsterSeeds/param.ccl
+++ b/AsterSeeds/param.ccl
@@ -71,6 +71,7 @@ KEYWORD shock_dir "Shock direction" STEERABLE=never
   "x" :: "Parallel to x axis"
   "y" :: "Parallel to y axis"
   "z" :: "Parallel to z axis"
+  "angle" :: "use rotate_angle_[x/y/z] instead"
 } "x"
 
 # parameters for 2D tests

--- a/AsterSeeds/src/1D_tests.cxx
+++ b/AsterSeeds/src/1D_tests.cxx
@@ -282,24 +282,21 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     vector<int> rotate_seq{2, 1, 0};
 
     if (CCTK_EQUALS(shock_dir, "x")) {
+      theta_z = 0.0;
+      theta_y = 0.0;
       theta_x = 0.0;
-      theta_y = 0.0;
-      theta_z = 0.0;
-      rotate_seq = {0, 1, 2};
     } else if (CCTK_EQUALS(shock_dir, "y")) {
-      theta_x = 0.5 * M_PI;
-      theta_y = 0.0;
       theta_z = 0.5 * M_PI;
-      rotate_seq = {1, 2, 0};
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
+      theta_y = 0.0;
       theta_x = 0.5 * M_PI;
-      theta_y = 0.5 * M_PI;
-      theta_z = 0.0;
-      rotate_seq = {2, 0, 1};
+    } else if (CCTK_EQUALS(shock_dir, "z")) {
+      theta_z = -0.5 * M_PI;
+      theta_y = -0.5 * M_PI;
+      theta_x = 0.0;
     } else {
-      theta_x = rotate_angle_x * M_PI;
-      theta_y = rotate_angle_y * M_PI;
       theta_z = rotate_angle_z * M_PI;
+      theta_y = rotate_angle_y * M_PI;
+      theta_x = rotate_angle_x * M_PI;
     }
 
     // Rotation matrix R_{ij} that rotates the coordinate system through a

--- a/AsterSeeds/src/1D_tests.cxx
+++ b/AsterSeeds/src/1D_tests.cxx
@@ -30,32 +30,32 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
 
   if (CCTK_EQUALS(test_case, "equilibrium")) {
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          rho(p.I) = 1.0;
-          velx(p.I) = 0.0;
-          vely(p.I) = 0.0;
-          velz(p.I) = 0.0;
-          press(p.I) = 1.0;
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+    grid.loop_all<1, 1, 1>(grid.nghostzones,
+                           [=] CCTK_HOST(const PointDesc &p)
+                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                 rho(p.I) = 1.0;
+                                 velx(p.I) = 0.0;
+                                 vely(p.I) = 0.0;
+                                 velz(p.I) = 0.0;
+                                 press(p.I) = 1.0;
+                                 eps(p.I) = eos_th.eps_from_valid_rho_press_ye(
+                                     rho(p.I), press(p.I), dummy_ye);
+                               });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+    grid.loop_all<1, 0, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_x(p.I) = 0.0;
+                                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+    grid.loop_all<0, 1, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_y(p.I) = 0.0;
+                                                 });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+    grid.loop_all<0, 0, 1>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_z(p.I) = 0.0;
+                                                 });
 
   } else if (CCTK_EQUALS(test_case, "sound wave")) {
     grid.loop_all<1, 1, 1>(
@@ -70,33 +70,33 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
                                                         dummy_ye);
         });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+    grid.loop_all<1, 0, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_x(p.I) = 0.0;
+                                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+    grid.loop_all<0, 1, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_y(p.I) = 0.0;
+                                                 });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-  
+    grid.loop_all<0, 0, 1>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_z(p.I) = 0.0;
+                                                 });
+
   } else if (CCTK_EQUALS(test_case, "Alfven wave")) {
     const CCTK_REAL A0 = 1.0;
     const CCTK_REAL va = 0.5;
-    const CCTK_REAL k = 2*M_PI;
+    const CCTK_REAL k = 2 * M_PI;
 
     grid.loop_all<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           rho(p.I) = 1.0;
           velx(p.I) = 0.0;
-          vely(p.I) = -va * A0 * cos(k*p.x);
-          velz(p.I) = -va * A0 * sin(k*p.x);
+          vely(p.I) = -va * A0 * cos(k * p.x);
+          velz(p.I) = -va * A0 * sin(k * p.x);
           press(p.I) = 0.5; // should add kinetic energy here
           eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
                                                         dummy_ye);
@@ -104,59 +104,60 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
 
     grid.loop_all<1, 0, 0>(
         grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = p.z*cos(k*p.x) - p.y*sin(k*p.x); });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = -p.z/2.0; });
-            //CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = p.x*sin(k*p.x) - p.z; });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = p.y/2.0; });
-            //CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = p.y - p.x*cos(k*p.x); });
-
-  } else if (CCTK_EQUALS(test_case, "shock tube")) {
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
         [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = 2.0;
-            velx(p.I) = 0.0;
-            vely(p.I) = 0.0;
-            velz(p.I) = 0.0;
-            press(p.I) = 2.0;
-          } else {
-            rho(p.I) = 1.0;
-            velx(p.I) = 0.0;
-            vely(p.I) = 0.0;
-            velz(p.I) = 0.0;
-            press(p.I) = 1.0;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
+          Avec_x(p.I) = p.z * cos(k * p.x) - p.y * sin(k * p.x);
         });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+    grid.loop_all<0, 1, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_y(p.I) = -p.z / 2.0;
+                                                 });
+    // CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = p.x*sin(k*p.x) - p.z; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+    grid.loop_all<0, 0, 1>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_z(p.I) = p.y / 2.0;
+                                                 });
+    // CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = p.y - p.x*cos(k*p.x); });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+  } else if (CCTK_EQUALS(test_case, "shock tube")) {
+    grid.loop_all<1, 1, 1>(grid.nghostzones,
+                           [=] CCTK_HOST(const PointDesc &p)
+                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                 if (p.x <= 0.0) {
+                                   rho(p.I) = 2.0;
+                                   velx(p.I) = 0.0;
+                                   vely(p.I) = 0.0;
+                                   velz(p.I) = 0.0;
+                                   press(p.I) = 2.0;
+                                 } else {
+                                   rho(p.I) = 1.0;
+                                   velx(p.I) = 0.0;
+                                   vely(p.I) = 0.0;
+                                   velz(p.I) = 0.0;
+                                   press(p.I) = 1.0;
+                                 }
+                                 eps(p.I) = eos_th.eps_from_valid_rho_press_ye(
+                                     rho(p.I), press(p.I), dummy_ye);
+                               });
+
+    grid.loop_all<1, 0, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_x(p.I) = 0.0;
+                                                 });
+
+    grid.loop_all<0, 1, 0>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_y(p.I) = 0.0;
+                                                 });
+
+    grid.loop_all<0, 0, 1>(grid.nghostzones, [=] CCTK_HOST(const PointDesc &p)
+                                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                                   Avec_z(p.I) = 0.0;
+                                                 });
 
   } else if (CCTK_EQUALS(test_case, "Balsara1")) {
-   
+
     CCTK_REAL rhol = 1.0;
     CCTK_REAL vxl = 0.0;
     CCTK_REAL vyl = 0.0;
@@ -173,159 +174,159 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     CCTK_REAL pressr = 0.1;
     CCTK_REAL Bxr = 0.5;
     CCTK_REAL Byr = -1.0;
-    CCTK_REAL Bzr = 0.0;    
-	 
+    CCTK_REAL Bzr = 0.0;
+
     if (CCTK_EQUALS(shock_dir, "x")) {
-   
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = rhol;
-            velx(p.I) = vxl;
-            vely(p.I) = vyl;
-            velz(p.I) = vzl;
-            press(p.I) = pressl;
 
-          } else {
-            rho(p.I) = rhor;
-            velx(p.I) = vxr;
-            vely(p.I) = vyr;
-            velz(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+            if (p.x <= 0.0) {
+              rho(p.I) = rhol;
+              velx(p.I) = vxl;
+              vely(p.I) = vyl;
+              velz(p.I) = vzl;
+              press(p.I) = pressl;
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) { 
-	       Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);  
-	    } else { 
-	       Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y); } });
+            } else {
+              rho(p.I) = rhor;
+              velx(p.I) = vxr;
+              vely(p.I) = vyr;
+              velz(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<1, 0, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.x <= 0.0) {
+                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
+                                   } else {
+                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
+                                   }
+                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_z(p.I) = Bxr * (p.y);  });
-    
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
+
     } else if (CCTK_EQUALS(shock_dir, "y")) {
 
-    //x-->y, y-->z, z-->x
-    Byl = 0.5;
-    Bzl = 1.0;
-    Bxl = 0.0;
-    Byr = 0.5;
-    Bzr = -1.0;
-    Bxr = 0.0;
+      // x-->y, y-->z, z-->x
+      Byl = 0.5;
+      Bzl = 1.0;
+      Bxl = 0.0;
+      Byr = 0.5;
+      Bzr = -1.0;
+      Bxr = 0.0;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.y <= 0.0) {
-            rho(p.I) = rhol;
-            vely(p.I) = vxl;
-            velz(p.I) = vyl;
-            velx(p.I) = vzl;
-            press(p.I) = pressl;
-
-          } else {
-            rho(p.I) = rhor;
-            vely(p.I) = vxr;
-            velz(p.I) = vyr;
-            velx(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.y <= 0.0) {
-               Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+              rho(p.I) = rhol;
+              vely(p.I) = vxl;
+              velz(p.I) = vyl;
+              velx(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z); } });
+              rho(p.I) = rhor;
+              vely(p.I) = vxr;
+              velz(p.I) = vyr;
+              velx(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.y <= 0.0) {
+                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+                                   } else {
+                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_x(p.I) = Byr * (p.z);  });
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
 
     } else if (CCTK_EQUALS(shock_dir, "z")) {
-    
-    //x-->z, y-->x, z-->y
-    Bzl = 0.5;
-    Bxl = 1.0;
-    Byl = 0.0;
-    Bzr = 0.5;
-    Bxr = -1.0;
-    Byr = 0.0;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.z <= 0.0) {
-            rho(p.I) = rhol;
-            velz(p.I) = vxl;
-            velx(p.I) = vyl;
-            vely(p.I) = vzl;
-            press(p.I) = pressl;
+      // x-->z, y-->x, z-->y
+      Bzl = 0.5;
+      Bxl = 1.0;
+      Byl = 0.0;
+      Bzr = 0.5;
+      Bxr = -1.0;
+      Byr = 0.0;
 
-          } else {
-            rho(p.I) = rhor;
-            velz(p.I) = vxr;
-            velx(p.I) = vyr;
-            vely(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.z <= 0.0) {
-               Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+              rho(p.I) = rhol;
+              velz(p.I) = vxl;
+              velx(p.I) = vyl;
+              vely(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x); } });
+              rho(p.I) = rhor;
+              velz(p.I) = vxr;
+              velx(p.I) = vyr;
+              vely(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<0, 0, 1>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.z <= 0.0) {
+                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+                                   } else {
+                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_y(p.I) = Bzr * (p.x);  });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
 
-    } else { CCTK_ERROR("Shock direction case not defined"); }
-    
+    } else {
+      CCTK_ERROR("Shock direction case not defined");
+    }
+
   } else if (CCTK_EQUALS(test_case, "Balsara2")) {
-   
+
     CCTK_REAL rhol = 1.0;
     CCTK_REAL vxl = 0.0;
     CCTK_REAL vyl = 0.0;
@@ -342,159 +343,159 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     CCTK_REAL pressr = 1.0;
     CCTK_REAL Bxr = 5.0;
     CCTK_REAL Byr = 0.7;
-    CCTK_REAL Bzr = 0.7;    
-	 
+    CCTK_REAL Bzr = 0.7;
+
     if (CCTK_EQUALS(shock_dir, "x")) {
-   
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = rhol;
-            velx(p.I) = vxl;
-            vely(p.I) = vyl;
-            velz(p.I) = vzl;
-            press(p.I) = pressl;
 
-          } else {
-            rho(p.I) = rhor;
-            velx(p.I) = vxr;
-            vely(p.I) = vyr;
-            velz(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+            if (p.x <= 0.0) {
+              rho(p.I) = rhol;
+              velx(p.I) = vxl;
+              vely(p.I) = vyl;
+              velz(p.I) = vzl;
+              press(p.I) = pressl;
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) { 
-	       Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);  
-	    } else { 
-	       Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y); } });
+            } else {
+              rho(p.I) = rhor;
+              velx(p.I) = vxr;
+              vely(p.I) = vyr;
+              velz(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<1, 0, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.x <= 0.0) {
+                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
+                                   } else {
+                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
+                                   }
+                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_z(p.I) = Bxr * (p.y);  });
-    
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
+
     } else if (CCTK_EQUALS(shock_dir, "y")) {
 
-    //x-->y, y-->z, z-->x
-    Byl = 5.0;
-    Bzl = 6.0;
-    Bxl = 6.0;
-    Byr = 5.0;
-    Bzr = 0.7;
-    Bxr = 0.7;
+      // x-->y, y-->z, z-->x
+      Byl = 5.0;
+      Bzl = 6.0;
+      Bxl = 6.0;
+      Byr = 5.0;
+      Bzr = 0.7;
+      Bxr = 0.7;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.y <= 0.0) {
-            rho(p.I) = rhol;
-            vely(p.I) = vxl;
-            velz(p.I) = vyl;
-            velx(p.I) = vzl;
-            press(p.I) = pressl;
-
-          } else {
-            rho(p.I) = rhor;
-            vely(p.I) = vxr;
-            velz(p.I) = vyr;
-            velx(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.y <= 0.0) {
-               Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+              rho(p.I) = rhol;
+              vely(p.I) = vxl;
+              velz(p.I) = vyl;
+              velx(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z); } });
+              rho(p.I) = rhor;
+              vely(p.I) = vxr;
+              velz(p.I) = vyr;
+              velx(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.y <= 0.0) {
+                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+                                   } else {
+                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_x(p.I) = Byr * (p.z);  });
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
 
     } else if (CCTK_EQUALS(shock_dir, "z")) {
-    
-    //x-->z, y-->x, z-->y
-    Bzl = 5.0;
-    Bxl = 6.0;
-    Byl = 6.0;
-    Bzr = 5.0;
-    Bxr = 0.7;
-    Byr = 0.7;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.z <= 0.0) {
-            rho(p.I) = rhol;
-            velz(p.I) = vxl;
-            velx(p.I) = vyl;
-            vely(p.I) = vzl;
-            press(p.I) = pressl;
+      // x-->z, y-->x, z-->y
+      Bzl = 5.0;
+      Bxl = 6.0;
+      Byl = 6.0;
+      Bzr = 5.0;
+      Bxr = 0.7;
+      Byr = 0.7;
 
-          } else {
-            rho(p.I) = rhor;
-            velz(p.I) = vxr;
-            velx(p.I) = vyr;
-            vely(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.z <= 0.0) {
-               Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+              rho(p.I) = rhol;
+              velz(p.I) = vxl;
+              velx(p.I) = vyl;
+              vely(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x); } });
+              rho(p.I) = rhor;
+              velz(p.I) = vxr;
+              velx(p.I) = vyr;
+              vely(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<0, 0, 1>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.z <= 0.0) {
+                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+                                   } else {
+                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_y(p.I) = Bzr * (p.x);  });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
 
-    } else { CCTK_ERROR("Shock direction case not defined"); }
-    
+    } else {
+      CCTK_ERROR("Shock direction case not defined");
+    }
+
   } else if (CCTK_EQUALS(test_case, "Balsara3")) {
-   
+
     CCTK_REAL rhol = 1.0;
     CCTK_REAL vxl = 0.0;
     CCTK_REAL vyl = 0.0;
@@ -511,159 +512,159 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     CCTK_REAL pressr = 0.1;
     CCTK_REAL Bxr = 10.0;
     CCTK_REAL Byr = 0.7;
-    CCTK_REAL Bzr = 0.7;    
-	 
+    CCTK_REAL Bzr = 0.7;
+
     if (CCTK_EQUALS(shock_dir, "x")) {
-   
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = rhol;
-            velx(p.I) = vxl;
-            vely(p.I) = vyl;
-            velz(p.I) = vzl;
-            press(p.I) = pressl;
 
-          } else {
-            rho(p.I) = rhor;
-            velx(p.I) = vxr;
-            vely(p.I) = vyr;
-            velz(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+            if (p.x <= 0.0) {
+              rho(p.I) = rhol;
+              velx(p.I) = vxl;
+              vely(p.I) = vyl;
+              velz(p.I) = vzl;
+              press(p.I) = pressl;
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) { 
-	       Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);  
-	    } else { 
-	       Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y); } });
+            } else {
+              rho(p.I) = rhor;
+              velx(p.I) = vxr;
+              vely(p.I) = vyr;
+              velz(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<1, 0, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.x <= 0.0) {
+                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
+                                   } else {
+                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
+                                   }
+                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_z(p.I) = Bxr * (p.y);  });
-    
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
+
     } else if (CCTK_EQUALS(shock_dir, "y")) {
 
-    //x-->y, y-->z, z-->x
-    Byl = 10.0;
-    Bzl = 7.0;
-    Bxl = 7.0;
-    Byr = 10.0;
-    Bzr = 0.7;
-    Bxr = 0.7;
+      // x-->y, y-->z, z-->x
+      Byl = 10.0;
+      Bzl = 7.0;
+      Bxl = 7.0;
+      Byr = 10.0;
+      Bzr = 0.7;
+      Bxr = 0.7;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.y <= 0.0) {
-            rho(p.I) = rhol;
-            vely(p.I) = vxl;
-            velz(p.I) = vyl;
-            velx(p.I) = vzl;
-            press(p.I) = pressl;
-
-          } else {
-            rho(p.I) = rhor;
-            vely(p.I) = vxr;
-            velz(p.I) = vyr;
-            velx(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.y <= 0.0) {
-               Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+              rho(p.I) = rhol;
+              vely(p.I) = vxl;
+              velz(p.I) = vyl;
+              velx(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z); } });
+              rho(p.I) = rhor;
+              vely(p.I) = vxr;
+              velz(p.I) = vyr;
+              velx(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.y <= 0.0) {
+                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+                                   } else {
+                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_x(p.I) = Byr * (p.z);  });
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
 
     } else if (CCTK_EQUALS(shock_dir, "z")) {
-    
-    //x-->z, y-->x, z-->y
-    Bzl = 10.0;
-    Bxl = 7.0;
-    Byl = 7.0;
-    Bzr = 10.0;
-    Bxr = 0.7;
-    Byr = 0.7;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.z <= 0.0) {
-            rho(p.I) = rhol;
-            velz(p.I) = vxl;
-            velx(p.I) = vyl;
-            vely(p.I) = vzl;
-            press(p.I) = pressl;
+      // x-->z, y-->x, z-->y
+      Bzl = 10.0;
+      Bxl = 7.0;
+      Byl = 7.0;
+      Bzr = 10.0;
+      Bxr = 0.7;
+      Byr = 0.7;
 
-          } else {
-            rho(p.I) = rhor;
-            velz(p.I) = vxr;
-            velx(p.I) = vyr;
-            vely(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.z <= 0.0) {
-               Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+              rho(p.I) = rhol;
+              velz(p.I) = vxl;
+              velx(p.I) = vyl;
+              vely(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x); } });
+              rho(p.I) = rhor;
+              velz(p.I) = vxr;
+              velx(p.I) = vyr;
+              vely(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<0, 0, 1>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.z <= 0.0) {
+                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+                                   } else {
+                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_y(p.I) = Bzr * (p.x);  });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
 
-    } else { CCTK_ERROR("Shock direction case not defined"); }
-  
+    } else {
+      CCTK_ERROR("Shock direction case not defined");
+    }
+
   } else if (CCTK_EQUALS(test_case, "Balsara4")) {
-   
+
     CCTK_REAL rhol = 1.0;
     CCTK_REAL vxl = 0.999;
     CCTK_REAL vyl = 0.0;
@@ -680,159 +681,159 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     CCTK_REAL pressr = 0.1;
     CCTK_REAL Bxr = 10.0;
     CCTK_REAL Byr = -7.0;
-    CCTK_REAL Bzr = -7.0;    
-	 
+    CCTK_REAL Bzr = -7.0;
+
     if (CCTK_EQUALS(shock_dir, "x")) {
-   
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = rhol;
-            velx(p.I) = vxl;
-            vely(p.I) = vyl;
-            velz(p.I) = vzl;
-            press(p.I) = pressl;
 
-          } else {
-            rho(p.I) = rhor;
-            velx(p.I) = vxr;
-            vely(p.I) = vyr;
-            velz(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+            if (p.x <= 0.0) {
+              rho(p.I) = rhol;
+              velx(p.I) = vxl;
+              vely(p.I) = vyl;
+              velz(p.I) = vzl;
+              press(p.I) = pressl;
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) { 
-	       Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);  
-	    } else { 
-	       Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y); } });
+            } else {
+              rho(p.I) = rhor;
+              velx(p.I) = vxr;
+              vely(p.I) = vyr;
+              velz(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<1, 0, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.x <= 0.0) {
+                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
+                                   } else {
+                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
+                                   }
+                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_z(p.I) = Bxr * (p.y);  });
-    
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
+
     } else if (CCTK_EQUALS(shock_dir, "y")) {
 
-    //x-->y, y-->z, z-->x
-    Byl = 10.0;
-    Bzl = 7.0;
-    Bxl = 7.0;
-    Byr = 10.0;
-    Bzr = -7.0;
-    Bxr = -7.0;
+      // x-->y, y-->z, z-->x
+      Byl = 10.0;
+      Bzl = 7.0;
+      Bxl = 7.0;
+      Byr = 10.0;
+      Bzr = -7.0;
+      Bxr = -7.0;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.y <= 0.0) {
-            rho(p.I) = rhol;
-            vely(p.I) = vxl;
-            velz(p.I) = vyl;
-            velx(p.I) = vzl;
-            press(p.I) = pressl;
-
-          } else {
-            rho(p.I) = rhor;
-            vely(p.I) = vxr;
-            velz(p.I) = vyr;
-            velx(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.y <= 0.0) {
-               Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+              rho(p.I) = rhol;
+              vely(p.I) = vxl;
+              velz(p.I) = vyl;
+              velx(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z); } });
+              rho(p.I) = rhor;
+              vely(p.I) = vxr;
+              velz(p.I) = vyr;
+              velx(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.y <= 0.0) {
+                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+                                   } else {
+                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_x(p.I) = Byr * (p.z);  });
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
 
     } else if (CCTK_EQUALS(shock_dir, "z")) {
-    
-    //x-->z, y-->x, z-->y
-    Bzl = 10.0;
-    Bxl = 7.0;
-    Byl = 7.0;
-    Bzr = 10.0;
-    Bxr = -7.0;
-    Byr = -7.0;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.z <= 0.0) {
-            rho(p.I) = rhol;
-            velz(p.I) = vxl;
-            velx(p.I) = vyl;
-            vely(p.I) = vzl;
-            press(p.I) = pressl;
+      // x-->z, y-->x, z-->y
+      Bzl = 10.0;
+      Bxl = 7.0;
+      Byl = 7.0;
+      Bzr = 10.0;
+      Bxr = -7.0;
+      Byr = -7.0;
 
-          } else {
-            rho(p.I) = rhor;
-            velz(p.I) = vxr;
-            velx(p.I) = vyr;
-            vely(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.z <= 0.0) {
-               Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+              rho(p.I) = rhol;
+              velz(p.I) = vxl;
+              velx(p.I) = vyl;
+              vely(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x); } });
+              rho(p.I) = rhor;
+              velz(p.I) = vxr;
+              velx(p.I) = vyr;
+              vely(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<0, 0, 1>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.z <= 0.0) {
+                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+                                   } else {
+                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_y(p.I) = Bzr * (p.x);  });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
 
-    } else { CCTK_ERROR("Shock direction case not defined"); }
-  
+    } else {
+      CCTK_ERROR("Shock direction case not defined");
+    }
+
   } else if (CCTK_EQUALS(test_case, "Balsara5")) {
-   
+
     CCTK_REAL rhol = 1.08;
     CCTK_REAL vxl = 0.4;
     CCTK_REAL vyl = 0.3;
@@ -849,157 +850,157 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
     CCTK_REAL pressr = 1.0;
     CCTK_REAL Bxr = 2.0;
     CCTK_REAL Byr = -0.7;
-    CCTK_REAL Bzr = 0.5;    
-	 
+    CCTK_REAL Bzr = 0.5;
+
     if (CCTK_EQUALS(shock_dir, "x")) {
-   
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.x <= 0.0) {
-            rho(p.I) = rhol;
-            velx(p.I) = vxl;
-            vely(p.I) = vyl;
-            velz(p.I) = vzl;
-            press(p.I) = pressl;
 
-          } else {
-            rho(p.I) = rhor;
-            velx(p.I) = vxr;
-            vely(p.I) = vyr;
-            velz(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+            if (p.x <= 0.0) {
+              rho(p.I) = rhol;
+              velx(p.I) = vxl;
+              vely(p.I) = vyl;
+              velz(p.I) = vzl;
+              press(p.I) = pressl;
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) { 
-	       Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);  
-	    } else { 
-	       Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y); } });
+            } else {
+              rho(p.I) = rhor;
+              velx(p.I) = vxr;
+              vely(p.I) = vyr;
+              velz(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<1, 0, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.x <= 0.0) {
+                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
+                                   } else {
+                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
+                                   }
+                                 });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_z(p.I) = Bxr * (p.y);  });
-    
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
+
     } else if (CCTK_EQUALS(shock_dir, "y")) {
 
-    //x-->y, y-->z, z-->x
-    Byl = 2.0;
-    Bzl = 0.3;
-    Bxl = 0.3;
-    Byr = 2.0;
-    Bzr = -0.7;
-    Bxr = 0.5;
+      // x-->y, y-->z, z-->x
+      Byl = 2.0;
+      Bzl = 0.3;
+      Bxl = 0.3;
+      Byr = 2.0;
+      Bzr = -0.7;
+      Bxr = 0.5;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.y <= 0.0) {
-            rho(p.I) = rhol;
-            vely(p.I) = vxl;
-            velz(p.I) = vyl;
-            velx(p.I) = vzl;
-            press(p.I) = pressl;
-
-          } else {
-            rho(p.I) = rhor;
-            vely(p.I) = vxr;
-            velz(p.I) = vyr;
-            velx(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.y <= 0.0) {
-               Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+              rho(p.I) = rhol;
+              vely(p.I) = vxl;
+              velz(p.I) = vyl;
+              velx(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z); } });
+              rho(p.I) = rhor;
+              vely(p.I) = vxr;
+              velz(p.I) = vyr;
+              velx(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+      grid.loop_all<0, 1, 0>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.y <= 0.0) {
+                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
+                                   } else {
+                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_x(p.I) = Byr * (p.z);  });
+      grid.loop_all<0, 0, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
+
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
 
     } else if (CCTK_EQUALS(shock_dir, "z")) {
-    
-    //x-->z, y-->x, z-->y
-    Bzl = 2.0;
-    Bxl = 0.3;
-    Byl = 0.3;
-    Bzr = 2.0;
-    Bxr = -0.7;
-    Byr = 0.5;
 
-    grid.loop_all<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          if (p.z <= 0.0) {
-            rho(p.I) = rhol;
-            velz(p.I) = vxl;
-            velx(p.I) = vyl;
-            vely(p.I) = vzl;
-            press(p.I) = pressl;
+      // x-->z, y-->x, z-->y
+      Bzl = 2.0;
+      Bxl = 0.3;
+      Byl = 0.3;
+      Bzr = 2.0;
+      Bxr = -0.7;
+      Byr = 0.5;
 
-          } else {
-            rho(p.I) = rhor;
-            velz(p.I) = vxr;
-            velx(p.I) = vyr;
-            vely(p.I) = vzr;
-            press(p.I) = pressr;
-          }
-          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                        dummy_ye);
-        });
-
-    grid.loop_all<0, 0, 1>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      grid.loop_all<1, 1, 1>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             if (p.z <= 0.0) {
-               Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+              rho(p.I) = rhol;
+              velz(p.I) = vxl;
+              velx(p.I) = vyl;
+              vely(p.I) = vzl;
+              press(p.I) = pressl;
+
             } else {
-               Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x); } });
+              rho(p.I) = rhor;
+              velz(p.I) = vxr;
+              velx(p.I) = vyr;
+              vely(p.I) = vzr;
+              press(p.I) = pressr;
+            }
+            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                          dummy_ye);
+          });
 
+      grid.loop_all<0, 0, 1>(grid.nghostzones,
+                             [=] CCTK_HOST(const PointDesc &p)
+                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                   if (p.z <= 0.0) {
+                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
+                                   } else {
+                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
+                                   }
+                                 });
 
-    grid.loop_all<1, 0, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
+      grid.loop_all<1, 0, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
 
-    grid.loop_all<0, 1, 0>(
-        grid.nghostzones,
-        [=] CCTK_HOST(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE {
-               Avec_y(p.I) = Bzr * (p.x);  });
+      grid.loop_all<0, 1, 0>(
+          grid.nghostzones,
+          [=] CCTK_HOST(const PointDesc &p)
+              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
 
-    } else { CCTK_ERROR("Shock direction case not defined"); }
-    
+    } else {
+      CCTK_ERROR("Shock direction case not defined");
+    }
+
   } else {
     CCTK_ERROR("Test case not defined");
   }

--- a/AsterSeeds/src/1D_tests.cxx
+++ b/AsterSeeds/src/1D_tests.cxx
@@ -156,850 +156,240 @@ extern "C" void Tests1D_Initialize(CCTK_ARGUMENTS) {
                                                    Avec_z(p.I) = 0.0;
                                                  });
 
-  } else if (CCTK_EQUALS(test_case, "Balsara1")) {
-
-    CCTK_REAL rhol = 1.0;
-    CCTK_REAL vxl = 0.0;
-    CCTK_REAL vyl = 0.0;
-    CCTK_REAL vzl = 0.0;
-    CCTK_REAL pressl = 1.0;
-    CCTK_REAL Bxl = 0.5;
-    CCTK_REAL Byl = 1.0;
-    CCTK_REAL Bzl = 0.0;
-
-    CCTK_REAL rhor = 0.125;
-    CCTK_REAL vxr = 0.0;
-    CCTK_REAL vyr = 0.0;
-    CCTK_REAL vzr = 0.0;
-    CCTK_REAL pressr = 0.1;
-    CCTK_REAL Bxr = 0.5;
-    CCTK_REAL Byr = -1.0;
-    CCTK_REAL Bzr = 0.0;
-
-    if (CCTK_EQUALS(shock_dir, "x")) {
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) {
-              rho(p.I) = rhol;
-              velx(p.I) = vxl;
-              vely(p.I) = vyl;
-              velz(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velx(p.I) = vxr;
-              vely(p.I) = vyr;
-              velz(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<1, 0, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.x <= 0.0) {
-                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
-                                   } else {
-                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
-                                   }
-                                 });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
-
-    } else if (CCTK_EQUALS(shock_dir, "y")) {
-
-      // x-->y, y-->z, z-->x
-      Byl = 0.5;
-      Bzl = 1.0;
-      Bxl = 0.0;
-      Byr = 0.5;
-      Bzr = -1.0;
-      Bxr = 0.0;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.y <= 0.0) {
-              rho(p.I) = rhol;
-              vely(p.I) = vxl;
-              velz(p.I) = vyl;
-              velx(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              vely(p.I) = vxr;
-              velz(p.I) = vyr;
-              velx(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 1, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.y <= 0.0) {
-                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
-                                   } else {
-                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
-                                   }
-                                 });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
-
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
-
-      // x-->z, y-->x, z-->y
-      Bzl = 0.5;
-      Bxl = 1.0;
-      Byl = 0.0;
-      Bzr = 0.5;
-      Bxr = -1.0;
-      Byr = 0.0;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.z <= 0.0) {
-              rho(p.I) = rhol;
-              velz(p.I) = vxl;
-              velx(p.I) = vyl;
-              vely(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velz(p.I) = vxr;
-              velx(p.I) = vyr;
-              vely(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 0, 1>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.z <= 0.0) {
-                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
-                                   } else {
-                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
-                                   }
-                                 });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
-
-    } else {
-      CCTK_ERROR("Shock direction case not defined");
-    }
-
-  } else if (CCTK_EQUALS(test_case, "Balsara2")) {
-
-    CCTK_REAL rhol = 1.0;
-    CCTK_REAL vxl = 0.0;
-    CCTK_REAL vyl = 0.0;
-    CCTK_REAL vzl = 0.0;
-    CCTK_REAL pressl = 30.0;
-    CCTK_REAL Bxl = 5.0;
-    CCTK_REAL Byl = 6.0;
-    CCTK_REAL Bzl = 6.0;
-
-    CCTK_REAL rhor = 1.0;
-    CCTK_REAL vxr = 0.0;
-    CCTK_REAL vyr = 0.0;
-    CCTK_REAL vzr = 0.0;
-    CCTK_REAL pressr = 1.0;
-    CCTK_REAL Bxr = 5.0;
-    CCTK_REAL Byr = 0.7;
-    CCTK_REAL Bzr = 0.7;
-
-    if (CCTK_EQUALS(shock_dir, "x")) {
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) {
-              rho(p.I) = rhol;
-              velx(p.I) = vxl;
-              vely(p.I) = vyl;
-              velz(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velx(p.I) = vxr;
-              vely(p.I) = vyr;
-              velz(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<1, 0, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.x <= 0.0) {
-                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
-                                   } else {
-                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
-                                   }
-                                 });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
-
-    } else if (CCTK_EQUALS(shock_dir, "y")) {
-
-      // x-->y, y-->z, z-->x
-      Byl = 5.0;
-      Bzl = 6.0;
-      Bxl = 6.0;
-      Byr = 5.0;
-      Bzr = 0.7;
-      Bxr = 0.7;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.y <= 0.0) {
-              rho(p.I) = rhol;
-              vely(p.I) = vxl;
-              velz(p.I) = vyl;
-              velx(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              vely(p.I) = vxr;
-              velz(p.I) = vyr;
-              velx(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 1, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.y <= 0.0) {
-                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
-                                   } else {
-                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
-                                   }
-                                 });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
-
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
-
-      // x-->z, y-->x, z-->y
-      Bzl = 5.0;
-      Bxl = 6.0;
-      Byl = 6.0;
-      Bzr = 5.0;
-      Bxr = 0.7;
-      Byr = 0.7;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.z <= 0.0) {
-              rho(p.I) = rhol;
-              velz(p.I) = vxl;
-              velx(p.I) = vyl;
-              vely(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velz(p.I) = vxr;
-              velx(p.I) = vyr;
-              vely(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 0, 1>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.z <= 0.0) {
-                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
-                                   } else {
-                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
-                                   }
-                                 });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
-
-    } else {
-      CCTK_ERROR("Shock direction case not defined");
-    }
-
-  } else if (CCTK_EQUALS(test_case, "Balsara3")) {
-
-    CCTK_REAL rhol = 1.0;
-    CCTK_REAL vxl = 0.0;
-    CCTK_REAL vyl = 0.0;
-    CCTK_REAL vzl = 0.0;
-    CCTK_REAL pressl = 1000.0;
-    CCTK_REAL Bxl = 10.0;
-    CCTK_REAL Byl = 7.0;
-    CCTK_REAL Bzl = 7.0;
-
-    CCTK_REAL rhor = 1.0;
-    CCTK_REAL vxr = 0.0;
-    CCTK_REAL vyr = 0.0;
-    CCTK_REAL vzr = 0.0;
-    CCTK_REAL pressr = 0.1;
-    CCTK_REAL Bxr = 10.0;
-    CCTK_REAL Byr = 0.7;
-    CCTK_REAL Bzr = 0.7;
-
-    if (CCTK_EQUALS(shock_dir, "x")) {
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) {
-              rho(p.I) = rhol;
-              velx(p.I) = vxl;
-              vely(p.I) = vyl;
-              velz(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velx(p.I) = vxr;
-              vely(p.I) = vyr;
-              velz(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<1, 0, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.x <= 0.0) {
-                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
-                                   } else {
-                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
-                                   }
-                                 });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
-
-    } else if (CCTK_EQUALS(shock_dir, "y")) {
-
-      // x-->y, y-->z, z-->x
-      Byl = 10.0;
-      Bzl = 7.0;
-      Bxl = 7.0;
-      Byr = 10.0;
-      Bzr = 0.7;
-      Bxr = 0.7;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.y <= 0.0) {
-              rho(p.I) = rhol;
-              vely(p.I) = vxl;
-              velz(p.I) = vyl;
-              velx(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              vely(p.I) = vxr;
-              velz(p.I) = vyr;
-              velx(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 1, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.y <= 0.0) {
-                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
-                                   } else {
-                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
-                                   }
-                                 });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
-
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
-
-      // x-->z, y-->x, z-->y
-      Bzl = 10.0;
-      Bxl = 7.0;
-      Byl = 7.0;
-      Bzr = 10.0;
-      Bxr = 0.7;
-      Byr = 0.7;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.z <= 0.0) {
-              rho(p.I) = rhol;
-              velz(p.I) = vxl;
-              velx(p.I) = vyl;
-              vely(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velz(p.I) = vxr;
-              velx(p.I) = vyr;
-              vely(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 0, 1>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.z <= 0.0) {
-                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
-                                   } else {
-                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
-                                   }
-                                 });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
-
-    } else {
-      CCTK_ERROR("Shock direction case not defined");
-    }
-
-  } else if (CCTK_EQUALS(test_case, "Balsara4")) {
-
-    CCTK_REAL rhol = 1.0;
-    CCTK_REAL vxl = 0.999;
-    CCTK_REAL vyl = 0.0;
-    CCTK_REAL vzl = 0.0;
-    CCTK_REAL pressl = 0.1;
-    CCTK_REAL Bxl = 10.0;
-    CCTK_REAL Byl = 7.0;
-    CCTK_REAL Bzl = 7.0;
-
-    CCTK_REAL rhor = 1.0;
-    CCTK_REAL vxr = -0.999;
-    CCTK_REAL vyr = 0.0;
-    CCTK_REAL vzr = 0.0;
-    CCTK_REAL pressr = 0.1;
-    CCTK_REAL Bxr = 10.0;
-    CCTK_REAL Byr = -7.0;
-    CCTK_REAL Bzr = -7.0;
-
-    if (CCTK_EQUALS(shock_dir, "x")) {
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) {
-              rho(p.I) = rhol;
-              velx(p.I) = vxl;
-              vely(p.I) = vyl;
-              velz(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velx(p.I) = vxr;
-              vely(p.I) = vyr;
-              velz(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<1, 0, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.x <= 0.0) {
-                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
-                                   } else {
-                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
-                                   }
-                                 });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
-
-    } else if (CCTK_EQUALS(shock_dir, "y")) {
-
-      // x-->y, y-->z, z-->x
-      Byl = 10.0;
-      Bzl = 7.0;
-      Bxl = 7.0;
-      Byr = 10.0;
-      Bzr = -7.0;
-      Bxr = -7.0;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.y <= 0.0) {
-              rho(p.I) = rhol;
-              vely(p.I) = vxl;
-              velz(p.I) = vyl;
-              velx(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              vely(p.I) = vxr;
-              velz(p.I) = vyr;
-              velx(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 1, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.y <= 0.0) {
-                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
-                                   } else {
-                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
-                                   }
-                                 });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
-
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
-
-      // x-->z, y-->x, z-->y
-      Bzl = 10.0;
-      Bxl = 7.0;
-      Byl = 7.0;
-      Bzr = 10.0;
-      Bxr = -7.0;
-      Byr = -7.0;
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.z <= 0.0) {
-              rho(p.I) = rhol;
-              velz(p.I) = vxl;
-              velx(p.I) = vyl;
-              vely(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velz(p.I) = vxr;
-              velx(p.I) = vyr;
-              vely(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 0, 1>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.z <= 0.0) {
-                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
-                                   } else {
-                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
-                                   }
-                                 });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
-
-    } else {
-      CCTK_ERROR("Shock direction case not defined");
-    }
-
-  } else if (CCTK_EQUALS(test_case, "Balsara5")) {
-
-    CCTK_REAL rhol = 1.08;
-    CCTK_REAL vxl = 0.4;
-    CCTK_REAL vyl = 0.3;
-    CCTK_REAL vzl = 0.2;
-    CCTK_REAL pressl = 0.95;
-    CCTK_REAL Bxl = 2.0;
-    CCTK_REAL Byl = 0.3;
-    CCTK_REAL Bzl = 0.3;
-
-    CCTK_REAL rhor = 1.0;
-    CCTK_REAL vxr = -0.45;
-    CCTK_REAL vyr = -0.2;
-    CCTK_REAL vzr = 0.2;
-    CCTK_REAL pressr = 1.0;
-    CCTK_REAL Bxr = 2.0;
-    CCTK_REAL Byr = -0.7;
-    CCTK_REAL Bzr = 0.5;
-
-    if (CCTK_EQUALS(shock_dir, "x")) {
-
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.x <= 0.0) {
-              rho(p.I) = rhol;
-              velx(p.I) = vxl;
-              vely(p.I) = vyl;
-              velz(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velx(p.I) = vxr;
-              vely(p.I) = vyr;
-              velz(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<1, 0, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.x <= 0.0) {
-                                     Avec_x(p.I) = Byl * (p.z) - Bzl * (p.y);
-                                   } else {
-                                     Avec_x(p.I) = Byr * (p.z) - Bzr * (p.y);
-                                   }
-                                 });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = 0.0; });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = Bxr * (p.y); });
-
-    } else if (CCTK_EQUALS(shock_dir, "y")) {
-
-      // x-->y, y-->z, z-->x
-      Byl = 2.0;
-      Bzl = 0.3;
-      Bxl = 0.3;
-      Byr = 2.0;
-      Bzr = -0.7;
+  } else if (CCTK_EQUALS(test_case, "Balsara1") ||
+             CCTK_EQUALS(test_case, "Balsara2") ||
+             CCTK_EQUALS(test_case, "Balsara3") ||
+             CCTK_EQUALS(test_case, "Balsara4") ||
+             CCTK_EQUALS(test_case, "Balsara5")) {
+
+    auto myNaN = numeric_limits<CCTK_REAL>::quiet_NaN();
+
+    CCTK_REAL rhol = myNaN;
+    CCTK_REAL vxl = myNaN;
+    CCTK_REAL vyl = myNaN;
+    CCTK_REAL vzl = myNaN;
+    CCTK_REAL pressl = myNaN;
+    CCTK_REAL Bxl = myNaN;
+    CCTK_REAL Byl = myNaN;
+    CCTK_REAL Bzl = myNaN;
+
+    CCTK_REAL rhor = myNaN;
+    CCTK_REAL vxr = myNaN;
+    CCTK_REAL vyr = myNaN;
+    CCTK_REAL vzr = myNaN;
+    CCTK_REAL pressr = myNaN;
+    CCTK_REAL Bxr = myNaN;
+    CCTK_REAL Byr = myNaN;
+    CCTK_REAL Bzr = myNaN;
+
+    if (CCTK_EQUALS(test_case, "Balsara1")) {
+      rhol = 1.0;
+      vxl = 0.0;
+      vyl = 0.0;
+      vzl = 0.0;
+      pressl = 1.0;
+      Bxl = 0.5;
+      Byl = 1.0;
+      Bzl = 0.0;
+
+      rhor = 0.125;
+      vxr = 0.0;
+      vyr = 0.0;
+      vzr = 0.0;
+      pressr = 0.1;
       Bxr = 0.5;
+      Byr = -1.0;
+      Bzr = 0.0;
+    } else if (CCTK_EQUALS(test_case, "Balsara2")) {
+      rhol = 1.0;
+      vxl = 0.0;
+      vyl = 0.0;
+      vzl = 0.0;
+      pressl = 30.0;
+      Bxl = 5.0;
+      Byl = 6.0;
+      Bzl = 6.0;
 
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.y <= 0.0) {
-              rho(p.I) = rhol;
-              vely(p.I) = vxl;
-              velz(p.I) = vyl;
-              velx(p.I) = vzl;
-              press(p.I) = pressl;
+      rhor = 1.0;
+      vxr = 0.0;
+      vyr = 0.0;
+      vzr = 0.0;
+      pressr = 1.0;
+      Bxr = 5.0;
+      Byr = 0.7;
+      Bzr = 0.7;
+    } else if (CCTK_EQUALS(test_case, "Balsara3")) {
+      rhol = 1.0;
+      vxl = 0.0;
+      vyl = 0.0;
+      vzl = 0.0;
+      pressl = 1000.0;
+      Bxl = 10.0;
+      Byl = 7.0;
+      Bzl = 7.0;
 
-            } else {
-              rho(p.I) = rhor;
-              vely(p.I) = vxr;
-              velz(p.I) = vyr;
-              velx(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
+      rhor = 1.0;
+      vxr = 0.0;
+      vyr = 0.0;
+      vzr = 0.0;
+      pressr = 0.1;
+      Bxr = 10.0;
+      Byr = 0.7;
+      Bzr = 0.7;
+    } else if (CCTK_EQUALS(test_case, "Balsara4")) {
+      rhol = 1.0;
+      vxl = 0.999;
+      vyl = 0.0;
+      vzl = 0.0;
+      pressl = 0.1;
+      Bxl = 10.0;
+      Byl = 7.0;
+      Bzl = 7.0;
 
-      grid.loop_all<0, 1, 0>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.y <= 0.0) {
-                                     Avec_y(p.I) = Bzl * (p.x) - Bxl * (p.z);
-                                   } else {
-                                     Avec_y(p.I) = Bzr * (p.x) - Bxr * (p.z);
-                                   }
-                                 });
-
-      grid.loop_all<0, 0, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_z(p.I) = 0.0; });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = Byr * (p.z); });
-
-    } else if (CCTK_EQUALS(shock_dir, "z")) {
-
-      // x-->z, y-->x, z-->y
-      Bzl = 2.0;
-      Bxl = 0.3;
+      rhor = 1.0;
+      vxr = -0.999;
+      vyr = 0.0;
+      vzr = 0.0;
+      pressr = 0.1;
+      Bxr = 10.0;
+      Byr = -7.0;
+      Bzr = -7.0;
+    } else if (CCTK_EQUALS(test_case, "Balsara5")) {
+      rhol = 1.08;
+      vxl = 0.4;
+      vyl = 0.3;
+      vzl = 0.2;
+      pressl = 0.95;
+      Bxl = 2.0;
       Byl = 0.3;
-      Bzr = 2.0;
-      Bxr = -0.7;
-      Byr = 0.5;
+      Bzl = 0.3;
 
-      grid.loop_all<1, 1, 1>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-            if (p.z <= 0.0) {
-              rho(p.I) = rhol;
-              velz(p.I) = vxl;
-              velx(p.I) = vyl;
-              vely(p.I) = vzl;
-              press(p.I) = pressl;
-
-            } else {
-              rho(p.I) = rhor;
-              velz(p.I) = vxr;
-              velx(p.I) = vyr;
-              vely(p.I) = vzr;
-              press(p.I) = pressr;
-            }
-            eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
-                                                          dummy_ye);
-          });
-
-      grid.loop_all<0, 0, 1>(grid.nghostzones,
-                             [=] CCTK_HOST(const PointDesc &p)
-                                 CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                   if (p.z <= 0.0) {
-                                     Avec_z(p.I) = Bxl * (p.y) - Byl * (p.x);
-                                   } else {
-                                     Avec_z(p.I) = Bxr * (p.y) - Byr * (p.x);
-                                   }
-                                 });
-
-      grid.loop_all<1, 0, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_x(p.I) = 0.0; });
-
-      grid.loop_all<0, 1, 0>(
-          grid.nghostzones,
-          [=] CCTK_HOST(const PointDesc &p)
-              CCTK_ATTRIBUTE_ALWAYS_INLINE { Avec_y(p.I) = Bzr * (p.x); });
-
+      rhor = 1.0;
+      vxr = -0.45;
+      vyr = -0.2;
+      vzr = 0.2;
+      pressr = 1.0;
+      Bxr = 2.0;
+      Byr = -0.7;
+      Bzr = 0.5;
     } else {
-      CCTK_ERROR("Shock direction case not defined");
+      CCTK_ERROR("Balsara type not defined");
     }
+
+    CCTK_REAL theta_x = myNaN;
+    CCTK_REAL theta_y = myNaN;
+    CCTK_REAL theta_z = myNaN;
+
+    if (CCTK_EQUALS(shock_dir, "x")) {
+      theta_x = 0.0;
+      theta_y = 0.0;
+      theta_z = 0.0;
+    } else if (CCTK_EQUALS(shock_dir, "y")) {
+      theta_x = 0.0;
+      theta_y = 0.0;
+      theta_z = 0.5 * M_PI;
+    } else if (CCTK_EQUALS(shock_dir, "z")) {
+      theta_x = 0.0;
+      theta_y = 0.5 * M_PI;
+      theta_z = 0.0;
+    } else {
+      theta_x = rotate_angle_x * M_PI;
+      theta_y = rotate_angle_y * M_PI;
+      theta_z = rotate_angle_z * M_PI;
+    }
+
+    // Rotation matrix R_{ij}
+    const auto calc_R = [&](const CCTK_REAL th_x, const CCTK_REAL th_y,
+                            const CCTK_REAL th_z) {
+      const mat<CCTK_REAL, 3> R_x{
+          1.0, 0.0, 0.0, 0.0, cos(th_x), -sin(th_x), 0.0, sin(th_x), cos(th_x)};
+      const mat<CCTK_REAL, 3> R_y{cos(th_y),  0.0, sin(th_y), 0.0, 1.0, 0.0,
+                                  -sin(th_y), 0.0, cos(th_y)};
+      const mat<CCTK_REAL, 3> R_z{
+          cos(th_z), -sin(th_z), 0.0, sin(th_z), cos(th_z), 0.0, 0.0, 0.0, 1.0};
+      // R_{ij} = Rz_{ik} Ry_{kl} Rx_{lj}
+      return mat<CCTK_REAL, 3>([&](int i, int j) ARITH_INLINE {
+        return sum<3>([&](int k) ARITH_INLINE {
+          return R_z(i, k) * sum<3>([&](int l) ARITH_INLINE {
+                   return R_y(k, l) * R_x(l, j);
+                 });
+        });
+      });
+    };
+
+    // Tranform vector
+    const auto transform_vec = [&](const vec<CCTK_REAL, 3> u_vec,
+                                   const mat<CCTK_REAL, 3> R_mat) {
+      return vec<CCTK_REAL, 3>([&](int i) ARITH_INLINE {
+        return sum<3>([&](int k)
+                          ARITH_INLINE { return R_mat(i, k) * u_vec(k); });
+      });
+    };
+
+    const auto R = calc_R(theta_x, theta_y, theta_z);
+    const auto Rinv = calc_R(-theta_x, -theta_y, -theta_z);
+
+    // B and v in current coordinates
+    const auto oldBls = transform_vec(vec<CCTK_REAL, 3>{Bxl, Byl, Bzl}, Rinv);
+    const auto oldBrs = transform_vec(vec<CCTK_REAL, 3>{Bxr, Byr, Bzr}, Rinv);
+    const auto oldvls = transform_vec(vec<CCTK_REAL, 3>{vxl, vyl, vzl}, Rinv);
+    const auto oldvrs = transform_vec(vec<CCTK_REAL, 3>{vxr, vyr, vzr}, Rinv);
+
+    grid.loop_all<1, 1, 1>(
+        grid.nghostzones,
+        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          const auto newxs = transform_vec(vec<CCTK_REAL, 3>{p.x, p.y, p.z}, R);
+
+          if (newxs(0) <= 0.0) {
+            rho(p.I) = rhol;
+            velx(p.I) = oldvls(0);
+            vely(p.I) = oldvls(1);
+            velz(p.I) = oldvls(2);
+            press(p.I) = pressl;
+
+          } else {
+            rho(p.I) = rhor;
+            velx(p.I) = oldvrs(0);
+            vely(p.I) = oldvrs(1);
+            velz(p.I) = oldvrs(2);
+            press(p.I) = pressr;
+          }
+          eps(p.I) = eos_th.eps_from_valid_rho_press_ye(rho(p.I), press(p.I),
+                                                        dummy_ye);
+        });
+
+    grid.loop_all<1, 0, 0>(
+        grid.nghostzones,
+        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          const auto newxs = transform_vec(vec<CCTK_REAL, 3>{p.x, p.y, p.z}, R);
+          if (newxs(0) <= 0.0) {
+            Avec_x(p.I) = oldBls(1) * (p.z);
+          } else {
+            Avec_x(p.I) = oldBrs(1) * (p.z);
+          }
+        });
+
+    grid.loop_all<0, 1, 0>(
+        grid.nghostzones,
+        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          const auto newxs = transform_vec(vec<CCTK_REAL, 3>{p.x, p.y, p.z}, R);
+          if (newxs(0) <= 0.0) {
+            Avec_y(p.I) = oldBls(2) * (p.x);
+          } else {
+            Avec_y(p.I) = oldBrs(2) * (p.x);
+          }
+        });
+
+    grid.loop_all<0, 0, 1>(
+        grid.nghostzones,
+        [=] CCTK_HOST(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          const auto newxs = transform_vec(vec<CCTK_REAL, 3>{p.x, p.y, p.z}, R);
+          if (newxs(0) <= 0.0) {
+            Avec_z(p.I) = oldBls(0) * (p.y);
+          } else {
+            Avec_z(p.I) = oldBrs(0) * (p.y);
+          }
+        });
 
   } else {
     CCTK_ERROR("Test case not defined");


### PR DESCRIPTION
For the purpose of test AMR boundary artifacts, we extend Balsara's test to arbitrary directions:
1. only the implementation of Balsara's test are modified, all the other modifications are made by `clang-format`,
2. the old parfile for Balsara's test should produce the exact same result as before.