### PR TITLE
Reset negative eps and pressure 

### DIFF
--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -174,9 +174,11 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
     }
 
     if (rep_first.failed()) {
-      printf("First C2P failed :( \n");
-      rep_first.debug_message();
-      printf("Calling the back up C2P.. \n");
+      if (debug_mode) {
+         printf("First C2P failed :( \n");
+         rep_first.debug_message();
+         printf("Calling the back up C2P.. \n");
+      }
       // Calling the second C2P
       switch (c2p_sec) {
       case c2p_second_t::Noble: {
@@ -193,9 +195,10 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType &eos_cold,
     }
 
     if (rep_first.failed() && rep_second.failed()) {
-      printf("Second C2P failed too :( :( \n");
-      rep_second.debug_message();
-
+      if (debug_mode) {
+         printf("Second C2P failed too :( :( \n");
+         rep_second.debug_message();
+      }
       // Treatment for BH interiors after C2P failures
       // NOTE: By default, alp_thresh=0 so the if condition below is never
       // triggered. One must be very careful when using this functionality and

--- a/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
+++ b/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
@@ -356,12 +356,15 @@ c2p_1DPalenzuela::solve(EOSType &eos_th, prim_vars &pv, prim_vars &pv_seeds,
       return;
     }
   } else if (pv.eps < rgeps.min) {
+   
     /*
     printf(
         "(pv.eps < rgeps.min) is true! pv.eps, rgeps.min: %26.16e, %26.16e \n",
         pv.eps, rgeps.min);
-    printf(" Not adjusting cons.. \n");
+    printf("Adjusting cons.. \n");
     */
+    pv.eps = rgeps.min;
+    pv.press = eos_th.press_from_valid_rho_eps_ye(pv.rho, pv.eps, pv.Ye);
     rep.set_range_eps(rgeps.min); // sets adjust_cons to true
   }
 

--- a/Con2PrimFactory/src/c2p_2DNoble.hxx
+++ b/Con2PrimFactory/src/c2p_2DNoble.hxx
@@ -260,7 +260,7 @@ c2p_2DNoble::solve(EOSType &eos_th, prim_vars &pv, prim_vars &pv_seeds,
   pv_seeds.rho = cv.dens / pv_seeds.w_lor;
 
   CCTK_REAL eps_min =
-      eos_th.range_eps_from_valid_rho_ye(pv_seeds.rho, pv_seeds.Ye).min;
+       eos_th.range_eps_from_valid_rho_ye(pv_seeds.rho, pv_seeds.Ye).min;
   CCTK_REAL eps_last = max({pv_seeds.eps, eps_min});
 
   /* get pressure seed from updated pv_seeds.rho */
@@ -408,12 +408,14 @@ c2p_2DNoble::solve(EOSType &eos_th, prim_vars &pv, prim_vars &pv_seeds,
       return;
     }
   } else if (pv.eps < rgeps.min) {
-    /*
+    /*    
     printf(
         "(pv.eps < rgeps.min) is true! pv.eps, rgeps.min: %26.16e, %26.16e \n",
         pv.eps, rgeps.min);
     printf(" Not adjusting cons.. \n");
     */
+    pv.eps = rgeps.min;
+    pv.press = eos_th.press_from_valid_rho_eps_ye(pv.rho, pv.eps, pv.Ye);
     rep.set_range_eps(rgeps.min); // sets adjust_cons to true by default
   }
 


### PR DESCRIPTION
After C2P, if a grid-point has negative eps, the value is reset to the eps_min provided by the parfile. Pressure is recomputed accordingly. 